### PR TITLE
Refactor scripts to load versions dynamically for CI testing

### DIFF
--- a/scripts/load-versions.sh
+++ b/scripts/load-versions.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Load versions for tools from either a tutorial's versions.yml or the repo root versions.yml
+# Exports: RUST_VERSION, OMNI_NODE_VERSION, CHAIN_SPEC_BUILDER_VERSION
+
+set -e
+
+# Detect repo root from this script's location
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
+
+# Inputs (optional):
+# - TUTORIAL_DIR: absolute path to tutorial directory (containing versions.yml)
+# - TUTORIAL_KEY: key in root versions.yml for per-tutorial overrides (e.g., zero_to_hero)
+
+_parse_flat_yaml() {
+  # Very simple YAML parser for flat key: value pairs (no nesting)
+  # Args: file_path, key
+  local file_path="$1"; shift
+  local key="$1"; shift
+  awk -v k="$key" '
+    BEGIN { FS=":" }
+    /^[[:space:]]*#/ { next }                # skip comments
+    NF==0 { next }                           # skip empty
+    {
+      # capture lines like: key: value or key: "value"
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1)
+      if ($1 == k) {
+        sub(/^[^:]*:[[:space:]]*/, "", $0)
+        # trim quotes and whitespace
+        gsub(/^[\"\'\s]+|[\"\'\s]+$/, "", $0)
+        print $0
+        exit 0
+      }
+    }
+  ' "$file_path"
+}
+
+_extract_block_value() {
+  # Extract a value for a subkey inside a top-level block in root versions.yml
+  # Args: file_path, block_key (e.g., zero_to_hero), sub_key (e.g., rust)
+  local file_path="$1"; shift
+  local block_key="$1"; shift
+  local sub_key="$1"; shift
+  awk -v block="$block_key" -v subk="$sub_key" '
+    /^[[:space:]]*#/ { next }
+    /^\s*$/ { next }
+    {
+      # Enter block when line is exactly: block:
+      if ($0 ~ "^" block ":[[:space:]]*$") { in_block=1; next }
+      # Leave block when a new top-level key is encountered
+      if ($0 ~ /^[^[:space:]].*:[[:space:]]*$/ && $0 !~ "^" block ":[[:space:]]*$") { in_block=0 }
+      if (in_block==1) {
+        # lines inside block: two or more spaces then key: value
+        if ($0 ~ /^[[:space:]]{2,}[^[:space:]]+:[[:space:]]*.+$/) {
+          line=$0
+          sub(/^\s+/, "", line)
+          split(line, parts, ":")
+          key=parts[1]
+          gsub(/^\s+|\s+$/, "", key)
+          if (key == subk) {
+            val=line
+            sub(/^[^:]*:[[:space:]]*/, "", val)
+            gsub(/^[\"\'\s]+|[\"\'\s]+$/, "", val)
+            print val
+            exit 0
+          }
+        }
+      }
+    }
+  ' "$file_path"
+}
+
+load_versions() {
+  local tutorial_dir="${TUTORIAL_DIR:-}"
+  local tutorial_key="${TUTORIAL_KEY:-}"
+
+  if [[ -n "$tutorial_dir" && -f "$tutorial_dir/versions.yml" ]]; then
+    # Prefer tutorial-local versions.yml (flat keys)
+    local rust=$(_parse_flat_yaml "$tutorial_dir/versions.yml" rust)
+    local omni=$(_parse_flat_yaml "$tutorial_dir/versions.yml" polkadot_omni_node)
+    local csb=$(_parse_flat_yaml "$tutorial_dir/versions.yml" chain_spec_builder)
+    if [[ -n "$rust" ]]; then export RUST_VERSION="$rust"; fi
+    if [[ -n "$omni" ]]; then export OMNI_NODE_VERSION="$omni"; fi
+    if [[ -n "$csb" ]]; then export CHAIN_SPEC_BUILDER_VERSION="$csb"; fi
+    return 0
+  fi
+
+  # Fallback to root versions.yml
+  local root_file="$REPO_ROOT/versions.yml"
+  if [[ ! -f "$root_file" ]]; then
+    echo "versions.yml not found at $REPO_ROOT" >&2
+    return 1
+  fi
+
+  # Defaults under versions:
+  local def_rust=$(_extract_block_value "$root_file" versions rust)
+  local def_omni=$(_extract_block_value "$root_file" versions polkadot_omni_node)
+  local def_csb=$(_extract_block_value "$root_file" versions chain_spec_builder)
+
+  export RUST_VERSION="$def_rust"
+  export OMNI_NODE_VERSION="$def_omni"
+  export CHAIN_SPEC_BUILDER_VERSION="$def_csb"
+
+  # Optional overrides by tutorial key
+  if [[ -z "$tutorial_key" && -n "$tutorial_dir" ]]; then
+    # Derive key from dir name: replace dashes with underscores
+    local slug
+    slug=$(basename "$tutorial_dir")
+    tutorial_key=${slug//-/_}
+  fi
+
+  if [[ -n "$tutorial_key" ]]; then
+    local ov_rust=$(_extract_block_value "$root_file" "$tutorial_key" rust)
+    local ov_omni=$(_extract_block_value "$root_file" "$tutorial_key" polkadot_omni_node)
+    local ov_csb=$(_extract_block_value "$root_file" "$tutorial_key" chain_spec_builder)
+    if [[ -n "$ov_rust" ]]; then export RUST_VERSION="$ov_rust"; fi
+    if [[ -n "$ov_omni" ]]; then export OMNI_NODE_VERSION="$ov_omni"; fi
+    if [[ -n "$ov_csb" ]]; then export CHAIN_SPEC_BUILDER_VERSION="$ov_csb"; fi
+  fi
+}
+
+# If the script is sourced, export variables; if executed, print them JSON-ish
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  load_versions
+  echo "RUST_VERSION=$RUST_VERSION"
+  echo "OMNI_NODE_VERSION=$OMNI_NODE_VERSION"
+  echo "CHAIN_SPEC_BUILDER_VERSION=$CHAIN_SPEC_BUILDER_VERSION"
+else
+  load_versions
+fi
+
+

--- a/scripts/prepare-node-for-tutorial.sh
+++ b/scripts/prepare-node-for-tutorial.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Build kitchensink-parachain and generate chain spec for a tutorial
+# Usage: scripts/prepare-node-for-tutorial.sh <tutorial-slug>
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <tutorial-slug>" >&2
+  exit 2
+fi
+
+SLUG="$1"
+REPO_ROOT=$(cd "$(dirname "$0")"/.. && pwd)
+TUTORIAL_DIR="$REPO_ROOT/tutorials/$SLUG"
+
+if [[ ! -d "$TUTORIAL_DIR" ]]; then
+  echo "Tutorial directory not found: $TUTORIAL_DIR" >&2
+  exit 3
+fi
+
+export TUTORIAL_DIR
+source "$REPO_ROOT/scripts/load-versions.sh"
+
+echo "Preparing node for tutorial '$SLUG'"
+echo "Using Rust ${RUST_VERSION}"
+
+# Ensure rust toolchain and targets
+pushd "$TUTORIAL_DIR/scripts" >/dev/null
+bash ./setup-rust.sh
+popd >/dev/null
+
+# Build kitchensink-parachain runtime
+pushd "$REPO_ROOT/kitchensink-parachain" >/dev/null
+echo "Building kitchensink-parachain runtime..."
+cargo build --release
+popd >/dev/null
+
+# Generate chain spec into kitchensink-parachain/chain_spec.json
+pushd "$TUTORIAL_DIR/scripts" >/dev/null
+bash ./generate-chain-spec.sh
+popd >/dev/null
+
+echo "Node preparation completed for '$SLUG'"
+
+

--- a/scripts/setup-tutorial-env.sh
+++ b/scripts/setup-tutorial-env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Setup environment for a given tutorial using its versions.yml
+# Usage: scripts/setup-tutorial-env.sh <tutorial-slug>
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <tutorial-slug>" >&2
+  exit 2
+fi
+
+SLUG="$1"
+REPO_ROOT=$(cd "$(dirname "$0")"/.. && pwd)
+TUTORIAL_DIR="$REPO_ROOT/tutorials/$SLUG"
+
+if [[ ! -d "$TUTORIAL_DIR" ]]; then
+  echo "Tutorial directory not found: $TUTORIAL_DIR" >&2
+  exit 3
+fi
+
+# Load versions with preference to tutorial-local versions.yml
+export TUTORIAL_DIR
+source "$REPO_ROOT/scripts/load-versions.sh"
+
+echo "Setting up tutorial '$SLUG' with versions:" \
+  "RUST=${RUST_VERSION}, OMNI=${OMNI_NODE_VERSION}, CSB=${CHAIN_SPEC_BUILDER_VERSION}"
+
+# Run tutorial-specific installers
+pushd "$TUTORIAL_DIR/scripts" >/dev/null
+
+echo "Installing Rust toolchain..."
+bash ./setup-rust.sh
+
+echo "Installing chain-spec-builder..."
+bash ./install-chain-spec-builder.sh
+
+echo "Installing polkadot-omni-node..."
+bash ./install-omni-node.sh
+
+popd >/dev/null
+
+echo "Environment setup completed for '$SLUG'"
+
+

--- a/tutorials/zero-to-hero/scripts/generate-chain-spec.sh
+++ b/tutorials/zero-to-hero/scripts/generate-chain-spec.sh
@@ -1,36 +1,38 @@
 #!/bin/bash
 # Chain Specification Generation Script
-# This script generates a development chain specification for the parachain
-
 set -e
 
-PARA_ID="1000"
-RELAY_CHAIN="paseo"
-RUNTIME_PATH="./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm"
+# Load versions and work under kitchensink-parachain
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR"/../../.. && pwd)
+TUTORIAL_DIR=$(cd "$SCRIPT_DIR"/.. && pwd)
+source "$REPO_ROOT/scripts/load-versions.sh"
+cd "$REPO_ROOT/kitchensink-parachain"
+
+PARA_ID="${PARA_ID:-1000}"
+RELAY_CHAIN="${RELAY_CHAIN:-paseo}"
+RUNTIME_PATH="${RUNTIME_PATH:-./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm}"
 
 echo "⛓️ Generating chain specification..."
 echo "📋 Configuration:"
-echo "  - Para ID: 1000"
-echo "  - Relay Chain: paseo"
-echo "  - Runtime: ./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm"
+echo "  - Para ID: ${PARA_ID}"
+echo "  - Relay Chain: ${RELAY_CHAIN}"
+echo "  - Runtime: ${RUNTIME_PATH}"
 
-# Check if runtime exists
-if [ ! -f "./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm" ]; then
-  echo "❌ Runtime WASM file not found: ./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm"
+if [ ! -f "${RUNTIME_PATH}" ]; then
+  echo "❌ Runtime WASM file not found: ${RUNTIME_PATH}"
   echo "💡 Make sure you have built the parachain runtime first"
   echo "💡 Try running: cargo build --release"
   exit 1
 fi
 
-# Generate chain specification
 chain-spec-builder create \
   -t development \
-  --relay-chain paseo \
-  --para-id 1000 \
-  --runtime ./target/release/wbuild/parachain-template-runtime/parachain_template_runtime.compact.compressed.wasm \
+  --relay-chain "${RELAY_CHAIN}" \
+  --para-id "${PARA_ID}" \
+  --runtime "${RUNTIME_PATH}" \
   named-preset development
 
-# Verify chain spec was created
 if [ ! -f "chain_spec.json" ]; then
   echo "❌ Chain specification generation failed"
   exit 1
@@ -40,13 +42,10 @@ echo "✅ Chain specification generated successfully!"
 echo "📄 Output file: chain_spec.json"
 echo "📊 File size: $(du -h chain_spec.json | cut -f1)"
 
-# Validate JSON
 if command -v jq >/dev/null 2>&1; then
   echo "🔍 Validating JSON structure..."
   if jq empty chain_spec.json; then
     echo "✅ Chain specification is valid JSON"
-    
-    # Extract key information
     CHAIN_NAME=$(jq -r '.name // "unknown"' chain_spec.json)
     echo "📋 Chain Name: $CHAIN_NAME"
   else

--- a/tutorials/zero-to-hero/scripts/install-chain-spec-builder.sh
+++ b/tutorials/zero-to-hero/scripts/install-chain-spec-builder.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 # Chain Spec Builder Installation Script
-# This script installs the staging-chain-spec-builder tool
-
 set -e
 
-CHAIN_SPEC_VERSION="10.0.0"
+# Load versions
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR"/../../.. && pwd)
+TUTORIAL_DIR=$(cd "$SCRIPT_DIR"/.. && pwd)
+source "$REPO_ROOT/scripts/load-versions.sh"
 
-echo "🔧 Installing staging-chain-spec-builder 10.0.0..."
+echo "🔧 Installing staging-chain-spec-builder ${CHAIN_SPEC_BUILDER_VERSION}..."
 
-# Install chain-spec-builder with locked dependencies
-cargo install --locked staging-chain-spec-builder@10.0.0
+cargo install --locked staging-chain-spec-builder@"${CHAIN_SPEC_BUILDER_VERSION}"
 
 echo "✅ Chain spec builder installation completed!"
-echo "📋 Installed version: 10.0.0"
+echo "📋 Installed version: ${CHAIN_SPEC_BUILDER_VERSION}"
 
-# Verify installation
 echo "🔍 Verifying installation..."
 chain-spec-builder --version

--- a/tutorials/zero-to-hero/scripts/install-omni-node.sh
+++ b/tutorials/zero-to-hero/scripts/install-omni-node.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-# Omni Node Installation Script  
-# This script installs the polkadot-omni-node
-
+# Omni Node Installation Script
 set -e
 
-OMNI_NODE_VERSION="0.5.0"
+# Load versions
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR"/../../.. && pwd)
+TUTORIAL_DIR=$(cd "$SCRIPT_DIR"/.. && pwd)
+source "$REPO_ROOT/scripts/load-versions.sh"
 
-echo "🚀 Installing polkadot-omni-node 0.5.0..."
+echo "🚀 Installing polkadot-omni-node ${OMNI_NODE_VERSION}..."
 
-# Install omni-node with locked dependencies
-cargo install --locked polkadot-omni-node@0.5.0
+cargo install --locked polkadot-omni-node@"${OMNI_NODE_VERSION}"
 
 echo "✅ Omni node installation completed!"
-echo "📋 Installed version: 0.5.0"
+echo "📋 Installed version: ${OMNI_NODE_VERSION}"
 
-# Verify installation
 echo "🔍 Verifying installation..."
 polkadot-omni-node --version

--- a/tutorials/zero-to-hero/scripts/setup-rust.sh
+++ b/tutorials/zero-to-hero/scripts/setup-rust.sh
@@ -1,29 +1,25 @@
 #!/bin/bash
 # Rust Setup Script
-# This script sets up Rust with the required version and components
-
 set -e
 
-RUST_VERSION="1.86"
+# Load versions from tutorial-local or root config
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR"/../../.. && pwd)
+TUTORIAL_DIR=$(cd "$SCRIPT_DIR"/.. && pwd)
+source "$REPO_ROOT/scripts/load-versions.sh"
 
-echo "🦀 Setting up Rust 1.86..."
+echo "🦀 Setting up Rust ${RUST_VERSION}..."
 echo "📦 Installing Rust toolchain and components..."
 
-# Set default Rust version
-rustup default 1.86
-
-# Add WASM target for the current platform
-rustup target add wasm32-unknown-unknown --toolchain 1.86
-
-# Add rust source for the current platform  
-rustup component add rust-src --toolchain 1.86
+rustup default "${RUST_VERSION}"
+rustup target add wasm32-unknown-unknown --toolchain "${RUST_VERSION}"
+rustup component add rust-src --toolchain "${RUST_VERSION}"
 
 echo "✅ Rust setup completed successfully!"
 echo "📋 Installed components:"
-echo "  - Rust toolchain: 1.86"
+echo "  - Rust toolchain: ${RUST_VERSION}"
 echo "  - WASM target: wasm32-unknown-unknown"
 echo "  - Rust source component"
 
-# Verify installation
 echo "🔍 Verifying installation..."
 rustup show

--- a/tutorials/zero-to-hero/versions.yml
+++ b/tutorials/zero-to-hero/versions.yml
@@ -1,0 +1,5 @@
+# Tutorial-specific dependency versions
+rust: "1.86"
+polkadot_omni_node: "0.5.0"
+chain_spec_builder: "10.0.0"
+


### PR DESCRIPTION
Solves #6

This pull request introduces a new, version-aware scripting system for tutorial setup and node preparation, with a focus on maintainability and consistency across environments. The main change is the introduction of a centralized version loader (`load-versions.sh`) that allows all relevant scripts to dynamically pick up tool versions from either a tutorial-local or root `versions.yml` file. Scripts for installing dependencies, setting up Rust, building the node, and running tests have been refactored to use this system. This ensures that tutorials can specify and override their required tool versions in a single place, reducing duplication and risk of version drift.

Key changes:

**Version Management Infrastructure:**
* Added `scripts/load-versions.sh`, a robust Bash utility to load tool versions from either a tutorial's `versions.yml` or the root config, and export them as environment variables for use in all setup scripts.
* Added `tutorials/zero-to-hero/versions.yml` to specify tutorial-specific versions for Rust, `polkadot-omni-node`, and `chain_spec_builder`.

**Script Refactoring for Version Awareness:**
* Refactored setup scripts (`setup-rust.sh`, `install-chain-spec-builder.sh`, `install-omni-node.sh`, and `generate-chain-spec.sh`) in `tutorials/zero-to-hero/scripts/` to source `load-versions.sh` and use the dynamically loaded version variables, removing hardcoded versions. [[1]](diffhunk://#diff-182e69c3a3c51c517287b9a8c4d52abdd0bbf93d9dfc6d33c056f336d73e4907L3-L27) [[2]](diffhunk://#diff-e83ec276ba654822f7c1c90f13ebbafe68f7751f0569c4fefcdc3c33af139044L3-L17) [[3]](diffhunk://#diff-677fa55b733bbd5d01ad6f718111addc41194b3caab7fd28806980c40353e478L3-L17) [[4]](diffhunk://#diff-515eabeebce4d7c98ca7338e6cbe37649df3e5f08e7e5e56cff515fdd7570271L3-L33)
* Improved `generate-chain-spec.sh` to work from the correct directory, use environment/configurable parameters, and provide better output and validation. [[1]](diffhunk://#diff-515eabeebce4d7c98ca7338e6cbe37649df3e5f08e7e5e56cff515fdd7570271L3-L33) [[2]](diffhunk://#diff-515eabeebce4d7c98ca7338e6cbe37649df3e5f08e7e5e56cff515fdd7570271L43-L49)

**New Orchestration Scripts:**
* Added `scripts/setup-tutorial-env.sh` to automate installing all dependencies for a tutorial using its `versions.yml`.
* Added `scripts/prepare-node-for-tutorial.sh` to build the node and generate the chain spec for a tutorial, also using versioned dependencies.

**Test Automation Improvements:**
* Updated E2E test (`zero-to-hero-e2e.test.ts`) to automatically ensure the correct version of `polkadot-omni-node` is installed and the chain spec is generated by invoking the new orchestration scripts, making tests more robust and less dependent on manual setup. [[1]](diffhunk://#diff-976cf7ab09c04f266f0746ea0372d5908f1dd1438b360acd4f36d0dcd06de9efR31-R42) [[2]](diffhunk://#diff-976cf7ab09c04f266f0746ea0372d5908f1dd1438b360acd4f36d0dcd06de9efL64-R91)