### PR TITLE
fix: remove automatic coverage badge commit to resolve branch protection conflict

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Generate coverage badge
         run: |
-          # Use core library coverage for badge
+          # Use core library coverage for badge (displayed in PR comments only)
           COVERAGE="${{ steps.coverage.outputs.core_percentage }}"
           if (( $(echo "$COVERAGE >= 80" | bc -l) )); then
             COLOR="brightgreen"
@@ -120,22 +120,8 @@ jobs:
           else
             COLOR="red"
           fi
-          mkdir -p .github/badges
-          curl -o .github/badges/coverage.svg "https://img.shields.io/badge/core%20coverage-${COVERAGE}%25-${COLOR}"
-
-      - name: Commit coverage badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-          # Ensure we're on master branch
-          git checkout master || git checkout -b master
-          git pull origin master || true
-
-          git add .github/badges/coverage.svg
-          git diff --staged --quiet || git commit -m "chore: update coverage badge [skip ci]"
-          git push origin master
+          echo "Coverage badge would be: ${COVERAGE}% (${COLOR})"
+          echo "Note: Badge is not automatically committed due to branch protection"
 
       - name: Comment coverage on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Removes automatic coverage badge commit step from the SDK workflow
- Resolves the workflow failure caused by attempting to push directly to the protected master branch

## Problem
The workflow was failing because it tried to commit and push the coverage badge update directly to the master branch, which has branch protection rules requiring changes to go through pull requests.

## Solution
- Removed the "Commit coverage badge" step that was causing the failure
- Coverage information is still displayed in PR comments where it's most useful
- The existing badge file will continue to show coverage from the last successful manual update

## Test plan
- [x] Verify workflow no longer attempts to commit badge
- [x] Confirm coverage reporting still works in PR comments
- [x] Check that workflow completes successfully on master pushes