### PR TITLE
fix(workflow): add guard for non-pull-request events in semantic labeler

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // Guard: only run on pull_request events
+            if (context.eventName !== 'pull_request') {
+              console.log(`Skipping: workflow triggered by '${context.eventName}' event, not 'pull_request'`);
+              return;
+            }
+
             const pr = context.payload.pull_request;
 
             // Check if semantic label already exists (manual override)


### PR DESCRIPTION
## Summary

Fixes the workflow failure that occurred after PR #27 was merged: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966629451

## Problem

The `auto-label-semantic.yml` workflow was failing when triggered by push events (e.g., after PR merge) because it tried to access `context.payload.pull_request` which doesn't exist in push event contexts.

## Solution

Added a guard at the beginning of the script to check if the event is a `pull_request` event. If not, the workflow gracefully skips execution instead of failing.

```javascript
if (context.eventName !== 'pull_request') {
  console.log(`Skipping: workflow triggered by '${context.eventName}' event, not 'pull_request'`);
  return;
}
```

## Testing

- ✅ Pre-commit hooks passed
- ✅ Conventional commit format followed
- This will prevent workflow failures on push events

## Related

- Fixes workflow run: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966629451
- Related to PR #27