### PR TITLE
fix(workflow): remove PR-specific ref from checkout step

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -12,11 +12,10 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout PR
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Analyze commits and apply label
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Fixes the workflow validation error: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966746931

## Problem

The workflow was failing with "Invalid workflow file" error on line 152 because the checkout step (line 19) was trying to access `${{ github.event.pull_request.head.ref }}` which doesn't exist in push event contexts, causing validation failure.

## Solution

Removed the PR-specific `ref` parameter from the checkout step. The checkout action will now use the default behavior (checking out the triggering commit), which works for all event types.

The guard added in PR #28 will handle skipping execution for non-PR events at the script level.

## Changes

```diff
- name: Checkout PR
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
-   ref: ${{ github.event.pull_request.head.ref }}
```

## Testing

- ✅ Pre-commit hooks passed
- ✅ Conventional commit format followed
- This should resolve the YAML validation error

## Related

- Fixes: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966746931
- Follow-up to PR #28