### PR TITLE
fix(workflow): add explicit job-level condition for pull_request events

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   analyze-commits:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

Another attempt to fix the recurring workflow validation errors.

## Problem

The workflow keeps failing when triggered by push events:
- https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966629451
- https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966746931
- https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18966834960

Even though the workflow is configured to only run on `pull_request` events, GitHub still validates it on push events (when the workflow file itself is changed).

## Solution

Added an explicit job-level condition:
```yaml
if: github.event_name == 'pull_request'
```

This ensures the job is skipped entirely if the event is not a pull request, preventing any validation or execution issues.

This is a belt-and-suspenders approach alongside:
- The guard in the script (PR #28)
- The generic checkout step (PR #29)

## Testing

- ✅ Pre-commit hooks passed
- ✅ Conventional commit format followed

## Related

- Follow-up to PR #28 and PR #29
- Fixes multiple workflow runs