### PR TITLE
fix(workflows): start Chopsticks before running XCM recipe tests

### DIFF
--- a/.github/workflows/release-on-breaking-change.yml
+++ b/.github/workflows/release-on-breaking-change.yml
@@ -263,6 +263,11 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Test all recipes
         id: test
         run: |
@@ -281,7 +286,46 @@ jobs:
               cd "$recipe"
               if grep -q "\"test\":" package.json; then
                 npm install || exit 1
-                npm test || exit 1
+
+                # Check if recipe needs Chopsticks
+                if grep -q "\"chopsticks\":" package.json; then
+                  echo "Starting Chopsticks for $recipe_name..."
+                  npm run chopsticks > chopsticks.log 2>&1 &
+                  CHOPSTICKS_PID=$!
+
+                  # Wait for Chopsticks to initialize (max 2 minutes)
+                  echo "Waiting for Chopsticks to initialize..."
+                  timeout 120 bash -c '
+                    until grep -q "RPC listening" chopsticks.log 2>/dev/null; do
+                      sleep 2
+                      echo "Still waiting for Chopsticks..."
+                    done
+                  ' || {
+                    echo "Chopsticks failed to start within 2 minutes"
+                    cat chopsticks.log
+                    exit 1
+                  }
+
+                  echo "Chopsticks is ready!"
+                  tail -20 chopsticks.log
+
+                  # Run tests
+                  npm test || {
+                    echo "Tests failed, stopping Chopsticks..."
+                    kill $CHOPSTICKS_PID || true
+                    pkill -f chopsticks || true
+                    cat chopsticks.log
+                    exit 1
+                  }
+
+                  # Stop Chopsticks
+                  echo "Stopping Chopsticks..."
+                  kill $CHOPSTICKS_PID || true
+                  pkill -f chopsticks || true
+                else
+                  # No Chopsticks needed, just run tests
+                  npm test || exit 1
+                fi
               fi
               cd ../..
             fi

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -135,6 +135,12 @@ jobs:
         if: ${{ github.event.inputs.skip_tests != 'true' }}
         uses: Swatinem/rust-cache@v2
 
+      - name: Setup Node.js
+        if: ${{ github.event.inputs.skip_tests != 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Test all recipes
         if: ${{ github.event.inputs.skip_tests != 'true' }}
         run: |
@@ -153,7 +159,46 @@ jobs:
               cd "$recipe"
               if grep -q "\"test\":" package.json; then
                 npm install || exit 1
-                npm test || exit 1
+
+                # Check if recipe needs Chopsticks
+                if grep -q "\"chopsticks\":" package.json; then
+                  echo "Starting Chopsticks for $recipe_name..."
+                  npm run chopsticks > chopsticks.log 2>&1 &
+                  CHOPSTICKS_PID=$!
+
+                  # Wait for Chopsticks to initialize (max 2 minutes)
+                  echo "Waiting for Chopsticks to initialize..."
+                  timeout 120 bash -c '
+                    until grep -q "RPC listening" chopsticks.log 2>/dev/null; do
+                      sleep 2
+                      echo "Still waiting for Chopsticks..."
+                    done
+                  ' || {
+                    echo "Chopsticks failed to start within 2 minutes"
+                    cat chopsticks.log
+                    exit 1
+                  }
+
+                  echo "Chopsticks is ready!"
+                  tail -20 chopsticks.log
+
+                  # Run tests
+                  npm test || {
+                    echo "Tests failed, stopping Chopsticks..."
+                    kill $CHOPSTICKS_PID || true
+                    pkill -f chopsticks || true
+                    cat chopsticks.log
+                    exit 1
+                  }
+
+                  # Stop Chopsticks
+                  echo "Stopping Chopsticks..."
+                  kill $CHOPSTICKS_PID || true
+                  pkill -f chopsticks || true
+                else
+                  # No Chopsticks needed, just run tests
+                  npm test || exit 1
+                fi
               fi
               cd ../..
             fi


### PR DESCRIPTION
## Summary

Fixes workflow failures for XCM recipes that require Chopsticks to be running during tests.

## Problem

The `release-on-breaking-change.yml` and `release-weekly.yml` workflows were failing when testing XCM recipes (like `teleport-assets`) because:
- Tests expect Chopsticks to be running on ports 8000-8002
- Workflows were not starting Chopsticks before running tests
- This caused connection timeout errors: "Connection timeout - Chopsticks not responding"

Reference: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18967500856

## Solution

Updated both workflows to:
1. Add Node.js setup step (required for Chopsticks)
2. Detect recipes that need Chopsticks by checking for `"chopsticks":` script in `package.json`
3. Start Chopsticks in background before running tests
4. Wait for Chopsticks to initialize (max 2 minutes) by monitoring logs
5. Run tests with Chopsticks running
6. Stop Chopsticks after tests complete (or on failure)
7. Display Chopsticks logs on failure for debugging

This implementation follows the same pattern already used in `test-xcm-recipes.yml` workflow (lines 116-161).

## Testing

Verified locally:
- ✅ Chopsticks starts successfully for teleport-assets recipe
- ✅ Tests connect to Chopsticks on the expected ports
- ✅ Workflow logic correctly detects recipes with Chopsticks script

## Changes

- `.github/workflows/release-on-breaking-change.yml`: Add Chopsticks support for test-and-release-recipes job
- `.github/workflows/release-weekly.yml`: Add Chopsticks support for test-recipes job