### PR TITLE
fix(workflows): create release PRs instead of pushing directly to master

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,88 @@
+name: Publish Release
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'releases/v*/manifest.yml'
+      - 'releases/v*/RELEASE_NOTES.md'
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect release version
+        id: version
+        run: |
+          # Get files changed in this commit
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+
+          # Find release version from changed manifest
+          VERSION=$(echo "$CHANGED_FILES" | grep -oP 'releases/\K(v[0-9]+\.[0-9]+\.[0-9]+)' | head -1)
+
+          if [ -z "$VERSION" ]; then
+            echo "No release version detected"
+            exit 0
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected release version: $VERSION"
+
+          # Check if tag already exists
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping release creation"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Git tag
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.version != ''
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Determine release type from commit message
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MSG" | grep -qi "breaking change"; then
+            TAG_MSG="Release $VERSION (breaking change)"
+          else
+            TAG_MSG="Release $VERSION"
+          fi
+
+          git tag -a $VERSION -m "$TAG_MSG"
+          git push origin $VERSION
+
+          echo "✅ Created and pushed tag $VERSION"
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.skip == 'false' && steps.version.outputs.version != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Determine release title from commit message
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MSG" | grep -qi "breaking change"; then
+            TITLE="Polkadot Cookbook $VERSION (Breaking Change)"
+          else
+            TITLE="Polkadot Cookbook $VERSION"
+          fi
+
+          # Create release
+          gh release create $VERSION \
+            --title "$TITLE" \
+            --notes-file "releases/$VERSION/RELEASE_NOTES.md" \
+            "releases/$VERSION/manifest.yml"
+
+          echo "✅ Created GitHub Release $VERSION"

--- a/.github/workflows/release-on-breaking-change.yml
+++ b/.github/workflows/release-on-breaking-change.yml
@@ -248,6 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -458,22 +459,58 @@ jobs:
           </div>
           EOF
 
-      - name: Commit and create release
+      - name: Create release branch and PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ steps.new_version.outputs.new_version }}
+          COMPONENT: ${{ needs.detect-breaking-change.outputs.component }}
+          PR_NUMBER: ${{ needs.detect-breaking-change.outputs.pr_number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Create and switch to release branch
+          BRANCH_NAME="release/$NEW_VERSION"
+          git checkout -b $BRANCH_NAME
+
+          # Commit release files
           git add releases/$NEW_VERSION/
           git commit -m "chore(release): $NEW_VERSION triggered by breaking change"
-          git push origin HEAD:master
 
-          git tag -a $NEW_VERSION -m "Release $NEW_VERSION (breaking change)"
-          git push origin $NEW_VERSION
+          # Push branch
+          git push origin $BRANCH_NAME
 
-          gh release create $NEW_VERSION \
-            --title "Polkadot Cookbook $NEW_VERSION (Breaking Change)" \
-            --notes-file releases/$NEW_VERSION/RELEASE_NOTES.md \
-            releases/$NEW_VERSION/manifest.yml
+          # Create PR
+          gh pr create \
+            --title "Release $NEW_VERSION (Breaking Change)" \
+            --body "$(cat <<'PRBODY'
+          ## Breaking Change Release $NEW_VERSION
+
+          ⚠️ This PR contains the release manifest and notes for version $NEW_VERSION, triggered by a breaking change in the **$COMPONENT**.
+
+          ### Changes
+          - Triggered by: ${COMPONENT} breaking change (PR #${PR_NUMBER})
+          - All recipes retested successfully
+          - Release manifest generated
+          - Release notes generated
+
+          ### Next Steps
+          Once this PR is merged:
+          1. A Git tag will be created automatically
+          2. A GitHub Release will be published
+          3. Release artifacts will be attached
+
+          ---
+
+          🤖 This PR was automatically created by the Release on Breaking Change workflow.
+          PRBODY
+          )" \
+            --label "semantic:major" \
+            --label "release"
+
+      - name: PR Created
+        run: |
+          echo "✅ Release PR created successfully!"
+          echo "Once the PR is merged, a separate workflow will:"
+          echo "  - Create the Git tag $NEW_VERSION"
+          echo "  - Publish the GitHub Release"

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -210,6 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -329,30 +330,58 @@ jobs:
           </div>
           EOF
 
-      - name: Commit manifest and release notes
+      - name: Create release branch and PR
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_VERSION: ${{ needs.check-changes.outputs.new_version }}
+          VERSION_BUMP: ${{ needs.check-changes.outputs.version_bump }}
+          LAST_TAG: ${{ needs.check-changes.outputs.last_tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Create and switch to release branch
+          BRANCH_NAME="release/$NEW_VERSION"
+          git checkout -b $BRANCH_NAME
+
+          # Commit release files
           git add releases/$NEW_VERSION/
           git commit -m "chore(release): add manifest and notes for $NEW_VERSION"
-          git push origin HEAD:master
 
-      - name: Create Git tag
-        env:
-          NEW_VERSION: ${{ needs.check-changes.outputs.new_version }}
-        run: |
-          git tag -a $NEW_VERSION -m "Release $NEW_VERSION"
-          git push origin $NEW_VERSION
+          # Push branch
+          git push origin $BRANCH_NAME
 
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_VERSION: ${{ needs.check-changes.outputs.new_version }}
+          # Create PR
+          gh pr create \
+            --title "Release $NEW_VERSION" \
+            --body "$(cat <<'PRBODY'
+          ## Weekly Recipe Release $NEW_VERSION
+
+          This PR contains the release manifest and notes for version $NEW_VERSION.
+
+          ### Changes
+          - Version bump: **$VERSION_BUMP** (from $LAST_TAG)
+          - All recipes tested successfully
+          - Release manifest generated
+          - Release notes generated
+
+          ### Next Steps
+          Once this PR is merged:
+          1. A Git tag will be created automatically
+          2. A GitHub Release will be published
+          3. Release artifacts will be attached
+
+          ---
+
+          🤖 This PR was automatically created by the Weekly Recipe Release workflow.
+          PRBODY
+          )" \
+            --label "semantic:patch" \
+            --label "release"
+
+      - name: PR Created
         run: |
-          gh release create $NEW_VERSION \
-            --title "Polkadot Cookbook $NEW_VERSION" \
-            --notes-file releases/$NEW_VERSION/RELEASE_NOTES.md \
-            releases/$NEW_VERSION/manifest.yml
+          echo "✅ Release PR created successfully!"
+          echo "Once the PR is merged, a separate workflow will:"
+          echo "  - Create the Git tag $NEW_VERSION"
+          echo "  - Publish the GitHub Release"


### PR DESCRIPTION
## Summary

Fixes the release workflow failures caused by branch protection rules that prevent direct pushes to master.

## Problem

The release workflows (`release-weekly.yml` and `release-on-breaking-change.yml`) were failing because they tried to push directly to master, which is protected:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
```

Reference: https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18968831320

## Solution

Redesigned the release workflow to work with branch protection:

### 1. Release Workflows Create PRs
- `release-weekly.yml` and `release-on-breaking-change.yml` now create a release branch and PR
- PR includes release manifest and notes
- PR is automatically labeled with `release` and semantic version labels
- Requires manual review and merge

### 2. New Publish Workflow
- Created `publish-release.yml` that triggers on push to master
- Detects when a release PR is merged (by checking for changes to `releases/v*/`)
- Automatically creates git tag and GitHub release
- Prevents duplicate releases if tag already exists

## Workflow Flow

```mermaid
graph LR
    A[Release Workflow] -->|Creates| B[Release Branch]
    B -->|Creates| C[Pull Request]
    C -->|Merged| D[Push to Master]
    D -->|Triggers| E[Publish Release Workflow]
    E -->|Creates| F[Git Tag]
    E -->|Creates| G[GitHub Release]
```

## Changes

### Modified Workflows
- ✅ `release-weekly.yml`: Create PR instead of direct push
- ✅ `release-on-breaking-change.yml`: Create PR instead of direct push
- ✅ Added `pull-requests: write` permission to both workflows

### New Workflow
- ✅ `publish-release.yml`: Automatically publish release after PR merge

## Testing

- The previous workflow run shows tests passed successfully
- This PR can be tested by manually triggering the weekly release workflow after merge
- The release PR creation can be verified
- The automatic tag/release creation will be tested when that PR is merged