### PR TITLE
fix(workflows): add CLI binaries to releases and remove branding

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,11 +8,11 @@ on:
       - 'releases/v*/RELEASE_NOTES.md'
 
 jobs:
-  publish-release:
+  detect-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      skip: ${{ steps.version.outputs.skip }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,6 +30,7 @@ jobs:
 
           if [ -z "$VERSION" ]; then
             echo "No release version detected"
+            echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -44,10 +45,117 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
+  build-cli-binaries:
+    needs: detect-version
+    if: needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
+    name: Build CLI Binary (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: dot
+            asset_name: dot-linux-amd64
+
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact_name: dot
+            asset_name: dot-linux-arm64
+            cross: true
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact_name: dot
+            asset_name: dot-macos-amd64
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact_name: dot
+            asset_name: dot-macos-arm64
+
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: dot.exe
+            asset_name: dot-windows-amd64.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (for cross-compilation)
+        if: matrix.cross
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build CLI binary
+        run: |
+          cd cli
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Prepare binary
+        shell: bash
+        run: |
+          cd cli/target/${{ matrix.target }}/release
+
+          # Strip binary (except on Windows and macOS arm64)
+          if [[ "${{ matrix.os }}" != "windows-latest" && "${{ matrix.target }}" != "aarch64-apple-darwin" ]]; then
+            strip ${{ matrix.artifact_name }} || true
+          fi
+
+          # Create archive
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            7z a ../../../${{ matrix.asset_name }}.zip ${{ matrix.artifact_name }}
+          else
+            tar czf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: |
+            cli/${{ matrix.asset_name }}.tar.gz
+            cli/${{ matrix.asset_name }}.zip
+          if-no-files-found: error
+
+  publish-release:
+    needs: [detect-version, build-cli-binaries]
+    if: needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Download all CLI binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: cli-artifacts
+
       - name: Create Git tag
-        if: steps.version.outputs.skip == 'false' && steps.version.outputs.version != ''
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.detect-version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -66,23 +174,31 @@ jobs:
           echo "✅ Created and pushed tag $VERSION"
 
       - name: Create GitHub Release
-        if: steps.version.outputs.skip == 'false' && steps.version.outputs.version != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.detect-version.outputs.version }}
         run: |
           # Determine release title from commit message
           COMMIT_MSG=$(git log -1 --pretty=%B)
           if echo "$COMMIT_MSG" | grep -qi "breaking change"; then
-            TITLE="Polkadot Cookbook $VERSION (Breaking Change)"
+            TITLE="Release $VERSION (Breaking Change)"
           else
-            TITLE="Polkadot Cookbook $VERSION"
+            TITLE="Release $VERSION"
           fi
 
-          # Create release
+          # Collect all CLI binary archives
+          CLI_ASSETS=""
+          for file in cli-artifacts/**/*.tar.gz cli-artifacts/**/*.zip; do
+            if [ -f "$file" ]; then
+              CLI_ASSETS="$CLI_ASSETS $file"
+            fi
+          done
+
+          # Create release with manifest and CLI binaries
           gh release create $VERSION \
             --title "$TITLE" \
             --notes-file "releases/$VERSION/RELEASE_NOTES.md" \
-            "releases/$VERSION/manifest.yml"
+            "releases/$VERSION/manifest.yml" \
+            $CLI_ASSETS
 
-          echo "✅ Created GitHub Release $VERSION"
+          echo "✅ Created GitHub Release $VERSION with CLI binaries"

--- a/.github/workflows/release-on-breaking-change.yml
+++ b/.github/workflows/release-on-breaking-change.yml
@@ -412,16 +412,8 @@ jobs:
           COMPONENT: ${{ needs.detect-breaking-change.outputs.component }}
           PR_NUMBER: ${{ needs.detect-breaking-change.outputs.pr_number }}
         run: |
-          cat > releases/$NEW_VERSION/RELEASE_NOTES.md <<'EOF'
-          <div align="center">
-            <img height="24px" alt="Polkadot" src="https://github.com/paritytech/polkadot-sdk/raw/master/docs/images/Polkadot_Logo_Horizontal_Pink_White.png#gh-dark-mode-only" />
-            <img height="24px" alt="Polkadot" src="https://github.com/paritytech/polkadot-sdk/raw/master/docs/images/Polkadot_Logo_Horizontal_Pink_Black.png#gh-light-mode-only" />
-          </div>
-
-          EOF
-
-          cat >> releases/$NEW_VERSION/RELEASE_NOTES.md <<EOF
-          # Polkadot Cookbook $NEW_VERSION
+          cat > releases/$NEW_VERSION/RELEASE_NOTES.md <<EOF
+          # Release $NEW_VERSION
 
           **⚠️ Breaking Change Release**
 
@@ -448,15 +440,7 @@ jobs:
 
           ---
 
-          **Status:** Alpha (v0.x.x) - Expect frequent changes and updates.
-
-          <div align="center">
-
-          Built by [Polkadot Developers](https://github.com/polkadot-developers)
-
-          [Recipes](https://github.com/polkadot-developers/polkadot-cookbook#-recipes) • [Contributing](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/CONTRIBUTING.md) • [Issues](https://github.com/polkadot-developers/polkadot-cookbook/issues)
-
-          </div>
+          **Status:** Alpha (v0.x.x)
           EOF
 
       - name: Create release branch and PR

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -272,16 +272,8 @@ jobs:
           LAST_TAG: ${{ needs.check-changes.outputs.last_tag }}
           VERSION_BUMP: ${{ needs.check-changes.outputs.version_bump }}
         run: |
-          cat > releases/$NEW_VERSION/RELEASE_NOTES.md <<'EOF'
-          <div align="center">
-            <img height="24px" alt="Polkadot" src="https://github.com/paritytech/polkadot-sdk/raw/master/docs/images/Polkadot_Logo_Horizontal_Pink_White.png#gh-dark-mode-only" />
-            <img height="24px" alt="Polkadot" src="https://github.com/paritytech/polkadot-sdk/raw/master/docs/images/Polkadot_Logo_Horizontal_Pink_Black.png#gh-light-mode-only" />
-          </div>
-
-          EOF
-
-          cat >> releases/$NEW_VERSION/RELEASE_NOTES.md <<EOF
-          # Polkadot Cookbook $NEW_VERSION
+          cat > releases/$NEW_VERSION/RELEASE_NOTES.md <<EOF
+          # Release $NEW_VERSION
 
           Released: $(date -u +"%Y-%m-%d")
 
@@ -319,15 +311,7 @@ jobs:
 
           ---
 
-          **Status:** Alpha (v0.x.x) - Expect frequent changes and updates.
-
-          <div align="center">
-
-          Built by [Polkadot Developers](https://github.com/polkadot-developers)
-
-          [Recipes](https://github.com/polkadot-developers/polkadot-cookbook#-recipes) • [Contributing](https://github.com/polkadot-developers/polkadot-cookbook/blob/master/CONTRIBUTING.md) • [Issues](https://github.com/polkadot-developers/polkadot-cookbook/issues)
-
-          </div>
+          **Status:** Alpha (v0.x.x)
           EOF
 
       - name: Create release branch and PR


### PR DESCRIPTION
## Summary

Addresses two issues with the release workflow:
1. CLI binaries were not being built and attached to releases
2. Release notes contained excessive branding

## Changes

### 1. CLI Binaries in Releases

Added automatic CLI binary building to the `publish-release.yml` workflow:

**Platforms:**
- Linux x86_64 (`dot-linux-amd64.tar.gz`)
- Linux ARM64 (`dot-linux-arm64.tar.gz`) 
- macOS Intel (`dot-macos-amd64.tar.gz`)
- macOS Apple Silicon (`dot-macos-arm64.tar.gz`)
- Windows x86_64 (`dot-windows-amd64.exe.zip`)

**Process:**
- `build-cli-binaries` job builds for all platforms in parallel
- Uses `cross` for cross-compilation (Linux ARM64)
- Binaries are stripped (except macOS ARM64 and Windows)
- Compressed archives uploaded as artifacts
- `publish-release` job downloads artifacts and attaches to release

**Benefits:**
- Users can download pre-built binaries directly from releases
- No need to install Rust toolchain to use the CLI
- Consistent release artifacts across platforms

### 2. Minimal Branding

**Removed:**
- Polkadot logo headers (dark/light mode images)
- "Built by Polkadot Developers" footer
- Links to Recipes/Contributing/Issues
- "Polkadot Cookbook" title prefix

**Kept:**
- Version number
- Release date
- Changes description
- Compatibility info
- Status (Alpha)

**Before:**
```markdown
<div align="center">
  <img ... />
</div>

# Polkadot Cookbook v0.1.0
...
<div align="center">
Built by Polkadot Developers
...
</div>
```

**After:**
```markdown
# Release v0.1.0

Released: 2025-10-31
...
**Status:** Alpha (v0.x.x)
```

## Testing

Can be tested by triggering the weekly release workflow after merge.

## Files Changed

- `.github/workflows/publish-release.yml` - Added CLI binary building
- `.github/workflows/release-weekly.yml` - Removed branding from notes
- `.github/workflows/release-on-breaking-change.yml` - Removed branding from notes