### PR TITLE
Fix CLI binary preparation in release workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,6 +101,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build CLI binary
+        shell: bash
         run: |
           cd cli
           if [ "${{ matrix.cross }}" = "true" ]; then
@@ -112,18 +113,29 @@ jobs:
       - name: Prepare binary
         shell: bash
         run: |
-          cd cli/target/${{ matrix.target }}/release
+          # Find the binary (it should be in cli/target/<target>/release)
+          BINARY_PATH=$(find cli/target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
+
+          if [ -z "$BINARY_PATH" ]; then
+            echo "ERROR: Binary not found!"
+            find cli/target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
+            exit 1
+          fi
+
+          echo "Found binary at: $BINARY_PATH"
+          BINARY_DIR=$(dirname "$BINARY_PATH")
+          cd "$BINARY_DIR"
 
           # Strip binary (except on Windows and macOS arm64)
           if [[ "${{ matrix.os }}" != "windows-latest" && "${{ matrix.target }}" != "aarch64-apple-darwin" ]]; then
             strip ${{ matrix.artifact_name }} || true
           fi
 
-          # Create archive
+          # Create archive in cli directory
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a ../../../${{ matrix.asset_name }}.zip ${{ matrix.artifact_name }}
+            7z a "$GITHUB_WORKSPACE/cli/${{ matrix.asset_name }}.zip" ${{ matrix.artifact_name }}
           else
-            tar czf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
+            tar czf "$GITHUB_WORKSPACE/cli/${{ matrix.asset_name }}.tar.gz" ${{ matrix.artifact_name }}
           fi
 
       - name: Upload artifact

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -82,6 +82,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build CLI binary
+        shell: bash
         run: |
           cd cli
           if [ "${{ matrix.cross }}" = "true" ]; then
@@ -93,18 +94,29 @@ jobs:
       - name: Prepare binary
         shell: bash
         run: |
-          cd cli/target/${{ matrix.target }}/release
+          # Find the binary (it should be in cli/target/<target>/release)
+          BINARY_PATH=$(find cli/target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
+
+          if [ -z "$BINARY_PATH" ]; then
+            echo "ERROR: Binary not found!"
+            find cli/target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
+            exit 1
+          fi
+
+          echo "Found binary at: $BINARY_PATH"
+          BINARY_DIR=$(dirname "$BINARY_PATH")
+          cd "$BINARY_DIR"
 
           # Strip binary (except on Windows and macOS arm64)
           if [[ "${{ matrix.os }}" != "windows-latest" && "${{ matrix.target }}" != "aarch64-apple-darwin" ]]; then
             strip ${{ matrix.artifact_name }} || true
           fi
 
-          # Create archive
+          # Create archive in cli directory
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a ../../../${{ matrix.asset_name }}.zip ${{ matrix.artifact_name }}
+            7z a "$GITHUB_WORKSPACE/cli/${{ matrix.asset_name }}.zip" ${{ matrix.artifact_name }}
           else
-            tar czf ../../../${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
+            tar czf "$GITHUB_WORKSPACE/cli/${{ matrix.asset_name }}.tar.gz" ${{ matrix.artifact_name }}
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
## Problem

CLI binary builds were succeeding but the prepare binary step was failing on all platforms:
- **Windows**: Using bash syntax in PowerShell environment
- **All platforms**: Unable to find binaries in expected paths

## Solution

1. **Added `shell: bash`** to the "Build CLI binary" step to ensure consistent bash execution across all platforms (including Windows)

2. **Made binary location more robust** by using `find` to locate binaries instead of hardcoded paths

3. **Added error handling** to show available binaries if expected one isn't found

4. **Used `$GITHUB_WORKSPACE`** for consistent archive paths across platforms

## Testing

Needs verification in CI that:
- All platform builds complete successfully
- Binaries are properly packaged into .tar.gz / .zip archives
- Artifacts are uploaded correctly

## Related

Fixes the failures from https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18970359151