### PR TITLE
Fix binary location for workspace builds

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -110,25 +110,15 @@ jobs:
             cargo build --release --target ${{ matrix.target }}
           fi
 
-      - name: Debug - List files
-        shell: bash
-        run: |
-          echo "=== Current directory ==="
-          pwd
-          echo "=== Looking for binaries ==="
-          find . -name "${{ matrix.artifact_name }}" -type f 2>/dev/null || echo "No binaries found"
-          echo "=== Checking cli directory structure ==="
-          ls -R cli/ 2>/dev/null | head -100 || echo "cli/ doesn't exist"
-
       - name: Prepare binary
         shell: bash
         run: |
-          # Find the binary (it should be in cli/target/<target>/release)
-          BINARY_PATH=$(find cli/target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
+          # In a Cargo workspace, binaries are in target/<target>/release, not cli/target
+          BINARY_PATH=$(find target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
 
           if [ -z "$BINARY_PATH" ]; then
             echo "ERROR: Binary not found!"
-            find cli/target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
+            find target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
             exit 1
           fi
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -94,12 +94,12 @@ jobs:
       - name: Prepare binary
         shell: bash
         run: |
-          # Find the binary (it should be in cli/target/<target>/release)
-          BINARY_PATH=$(find cli/target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
+          # In a Cargo workspace, binaries are in target/<target>/release, not cli/target
+          BINARY_PATH=$(find target -type f -name "${{ matrix.artifact_name }}" | grep -E "/${{ matrix.target }}/release/${{ matrix.artifact_name }}$" | head -1)
 
           if [ -z "$BINARY_PATH" ]; then
             echo "ERROR: Binary not found!"
-            find cli/target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
+            find target -type f -name "${{ matrix.artifact_name }}" || echo "No binaries found at all"
             exit 1
           fi
 


### PR DESCRIPTION
## Root Cause

When building in a Cargo workspace, binaries are placed in the **workspace root's** `target/` directory, not in `cli/target/`. 

Our workflows were looking in `cli/target/<target>/release/` but the binaries were actually at `target/<target>/release/`.

## Solution

Updated both `publish-release.yml` and `release-cli.yml` to:
- Search for binaries in `target/` instead of `cli/target/`
- Added clarifying comments about workspace behavior

## Verification

Tested locally:
```bash
cd cli && cargo build --release --target aarch64-apple-darwin
# Binary created at: ../target/aarch64-apple-darwin/release/dot
# NOT at: target/aarch64-apple-darwin/release/dot
```

## Related

- Fixes failures from https://github.com/polkadot-developers/polkadot-cookbook/actions/runs/18970696865
- Part of complete CLI binary build fix along with PR #37 (OpenSSL) and PR #39 (bash shell)