### PR TITLE
Rename macOS binaries for clarity

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,12 +69,12 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: dot
-            asset_name: dot-macos-amd64
+            asset_name: dot-macos-intel
 
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: dot
-            asset_name: dot-macos-arm64
+            asset_name: dot-macos-apple-silicon
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -50,12 +50,12 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: dot
-            asset_name: dot-macos-amd64
+            asset_name: dot-macos-intel
 
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact_name: dot
-            asset_name: dot-macos-arm64
+            asset_name: dot-macos-apple-silicon
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -179,13 +179,13 @@ jobs:
 
           ### macOS (Intel)
           \`\`\`bash
-          curl -L https://github.com/polkadot-developers/polkadot-cookbook/releases/download/cli-v${VERSION}/dot-macos-amd64.tar.gz | tar xz
+          curl -L https://github.com/polkadot-developers/polkadot-cookbook/releases/download/cli-v${VERSION}/dot-macos-intel.tar.gz | tar xz
           sudo mv dot /usr/local/bin/
           \`\`\`
 
           ### macOS (Apple Silicon)
           \`\`\`bash
-          curl -L https://github.com/polkadot-developers/polkadot-cookbook/releases/download/cli-v${VERSION}/dot-macos-arm64.tar.gz | tar xz
+          curl -L https://github.com/polkadot-developers/polkadot-cookbook/releases/download/cli-v${VERSION}/dot-macos-apple-silicon.tar.gz | tar xz
           sudo mv dot /usr/local/bin/
           \`\`\`
 


### PR DESCRIPTION
## Problem

The current macOS binary names use technical terms that may confuse users:
- `dot-macos-amd64.tar.gz` - Not obvious this is for Intel Macs
- `dot-macos-arm64.tar.gz` - Not obvious this is for Apple Silicon

## Solution

Renamed the binaries to be more user-friendly:
- `dot-macos-amd64` → `dot-macos-intel`
- `dot-macos-arm64` → `dot-macos-apple-silicon`

Also updated the installation instructions in release notes to use the new names.

## Impact

- Clearer for macOS users which binary to download
- Better user experience, especially for non-technical users
- Consistent with how Apple markets their processors

## Files Changed

- `.github/workflows/publish-release.yml` - Updated matrix asset names
- `.github/workflows/release-cli.yml` - Updated matrix asset names and installation docs