### PR TITLE
hotfix: fix CLI path in release workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build CLI binary
         shell: bash
         run: |
-          cd cli
+          cd dot/cli
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}
           else

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build CLI binary
         shell: bash
         run: |
-          cd cli
+          cd dot/cli
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --locked --target ${{ matrix.target }}
           else


### PR DESCRIPTION
## Problem
The v0.4.0 release workflow is failing because both release workflows reference an incorrect path.

**Error:** `cd: cli: No such file or directory`

## Root Cause
Both `.github/workflows/publish-release.yml` and `.github/workflows/release-cli.yml` have:
```bash
cd cli
```

But the actual CLI path in the workspace is `dot/cli`.

## Fix
Changed `cd cli` to `cd dot/cli` in both workflow files (lines 106 and 87 respectively).

## Impact
This unblocks the v0.4.0 release that's currently failing. All 5 platform builds (Linux x64/ARM, macOS Intel/ARM, Windows) were failing with the same path error.

## Testing
The fix is straightforward - correcting a hardcoded path. The workflow will be validated when this PR is merged and the release workflow re-runs.