### PR TITLE
docs: add status badges to individual recipe READMEs

### DIFF
--- a/polkadot-docs/parachains/customize-runtime/add-existing-pallets/README.md
+++ b/polkadot-docs/parachains/customize-runtime/add-existing-pallets/README.md
@@ -8,6 +8,8 @@ polkadot_sdk_version: "polkadot-v2503.0.1"
 
 # Add Existing Pallets to Runtime
 
+[![Test Status](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/test-polkadot-docs.yml/badge.svg?job=add-existing-pallets)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/test-polkadot-docs.yml)
+
 This project verifies the [Add Existing Pallets](https://docs.polkadot.com/parachains/customize-runtime/add-existing-pallets/) guide from docs.polkadot.com.
 
 ## What This Tests

--- a/polkadot-docs/parachains/set-up-parachain-template/README.md
+++ b/polkadot-docs/parachains/set-up-parachain-template/README.md
@@ -8,6 +8,8 @@ polkadot_sdk_version: "polkadot-v2503.0.1"
 
 # Set Up the Parachain Template
 
+[![Test Status](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/test-polkadot-docs.yml/badge.svg?job=set-up-parachain-template)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/test-polkadot-docs.yml)
+
 This project verifies the [Set Up the Parachain Template](https://docs.polkadot.com/parachains/launch-a-parachain/set-up-the-parachain-template/) guide from docs.polkadot.com.
 
 ## What This Tests


### PR DESCRIPTION
## Summary

- Add workflow status badges to `set-up-parachain-template` README
- Add workflow status badges to `add-existing-pallets` README

This allows users to see test status directly when viewing each recipe, rather than having to navigate to the parent polkadot-docs README.

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Verify badge links point to correct workflow