### PR TITLE
fix(ci): pin cross version to 0.2.4 for Rust 1.91 compatibility

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install cross (for cross-compilation)
         if: matrix.cross
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --locked
+          cargo install cross@0.2.4 --locked
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install cross (for cross-compilation)
         if: matrix.cross
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --locked
+          cargo install cross@0.2.4 --locked
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

- Pin `cross` to version 0.2.4 in release workflows

## Problem

`cross 0.2.5` requires Rust 1.92.0+, but the repo uses Rust 1.91. This caused the aarch64-linux build to fail:

```
error: cannot install package `cross 0.2.5`, it requires rustc 1.92.0 or newer, while the currently active rustc version is 1.91.1
```

## Solution

Pin `cross` to version 0.2.4 which is compatible with Rust 1.91.

## Test plan

- [ ] Re-run the release workflow to verify aarch64-linux build passes