### PR TITLE
chore(polkadot-docs): standardize on Rust 1.91 across all guides

### DIFF
--- a/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/rust-toolchain.toml
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# This rust-toolchain.toml is used to match the Polkadot SDK version
-# polkadot-sdk-parachain-template v0.0.4 uses polkadot-sdk 2503.0.1
 [toolchain]
-channel = "1.82"
+channel = "1.91"
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/rust-toolchain.toml
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# This rust-toolchain.toml is used to match the Polkadot SDK version
-# polkadot-sdk-parachain-template v0.0.4 uses polkadot-sdk 2503.0.1
 [toolchain]
-channel = "1.82"
+channel = "1.91"
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/rust-toolchain.toml
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/rust-toolchain.toml
@@ -1,5 +1,5 @@
-# This rust-toolchain.toml is used to match the Polkadot SDK version
-# polkadot-sdk-parachain-template v0.0.4 uses polkadot-sdk 2503.0.1
 [toolchain]
-channel = "1.82"
+channel = "1.91"
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

- Update mock-runtime, pallet-testing, and benchmark-pallet guides to use Rust 1.91
- Standardize rust-toolchain.toml format across all pallet development guides with consistent configuration (rustfmt, clippy components and minimal profile)

## Test plan

- [x] Verify CI passes for polkadot-docs-mock-runtime.yml
- [x] Verify CI passes for polkadot-docs-pallet-testing.yml
- [x] Verify CI passes for polkadot-docs-benchmark-pallet.yml