### PR TITLE
fix(release): enable variable expansion in release PR body

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -355,7 +355,7 @@ jobs:
           # Create PR
           gh pr create \
             --title "Release $NEW_VERSION" \
-            --body "$(cat <<'PRBODY'
+            --body "$(cat <<PRBODY
           ## Weekly Recipe Release $NEW_VERSION
 
           This PR contains the release manifest and notes for version $NEW_VERSION.
@@ -374,7 +374,7 @@ jobs:
 
           ---
 
-          🤖 This PR was automatically created by the Weekly Recipe Release workflow.
+          This PR was automatically created by the Weekly Recipe Release workflow.
           PRBODY
           )" \
             --label "semantic:patch" \


### PR DESCRIPTION
## Summary

- Fix heredoc syntax in release-weekly.yml to enable shell variable expansion
- Changes `<<'PRBODY'` to `<<PRBODY` so `$NEW_VERSION`, `$VERSION_BUMP`, and `$LAST_TAG` are properly substituted

## Test plan

- [ ] Trigger the weekly release workflow manually to verify variables are expanded in the PR body