### PR TITLE
feat(ci): notify maintainers on polkadot-docs test failures

### DIFF
--- a/.github/workflows/notify-docs-failure.yml
+++ b/.github/workflows/notify-docs-failure.yml
@@ -1,0 +1,75 @@
+name: Notify Docs Failure
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        required: true
+        type: string
+        description: 'Human-readable name of the workflow that failed'
+      guide_path:
+        required: true
+        type: string
+        description: 'Path to the guide directory'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read maintainers
+        id: maintainers
+        run: |
+          MAINTAINERS=$(cat polkadot-docs/MAINTAINERS | tr '\n' ' ')
+          echo "list=$MAINTAINERS" >> $GITHUB_OUTPUT
+
+      - name: Check for existing issue
+        id: check_issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_TITLE="[Test Failure] ${{ inputs.workflow_name }}"
+          EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number // empty')
+          echo "existing_issue=$EXISTING_ISSUE" >> $GITHUB_OUTPUT
+          echo "title=$ISSUE_TITLE" >> $GITHUB_OUTPUT
+
+      - name: Create or update issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_TITLE="${{ steps.check_issue.outputs.title }}"
+          MAINTAINERS="${{ steps.maintainers.outputs.list }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          BODY="The **${{ inputs.workflow_name }}** guide test is failing on master.
+
+          **Details:**
+          - Guide: \`${{ inputs.guide_path }}\`
+          - Commit: \`${{ github.sha }}\`
+          - Failed run: [View logs]($RUN_URL)
+
+          cc $MAINTAINERS"
+
+          if [ -n "${{ steps.check_issue.outputs.existing_issue }}" ]; then
+            # Add comment to existing issue
+            COMMENT="Test still failing.
+
+          **Details:**
+          - Commit: \`${{ github.sha }}\`
+          - Failed run: [View logs]($RUN_URL)"
+
+            gh issue comment ${{ steps.check_issue.outputs.existing_issue }} --body "$COMMENT"
+            echo "Added comment to issue #${{ steps.check_issue.outputs.existing_issue }}"
+          else
+            # Create new issue
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body "$BODY" \
+              --label "test-failure,polkadot-docs"
+            echo "Created new issue"
+          fi

--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -65,3 +65,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/add-existing-pallets
           npm test
         timeout-minutes: 60
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Add Existing Pallets'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/add-existing-pallets'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -65,3 +65,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/add-pallet-instances
           npm test
         timeout-minutes: 60
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Add Pallet Instances'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/add-pallet-instances'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -50,3 +50,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet
           npm test
         timeout-minutes: 45
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Benchmark Pallet'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -65,3 +65,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet
           npm test
         timeout-minutes: 60
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Create a Pallet'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -42,3 +42,14 @@ jobs:
           cd polkadot-docs/parachains/install-polkadot-sdk
           npm test
         timeout-minutes: 15
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Install Polkadot SDK'
+      guide_path: 'polkadot-docs/parachains/install-polkadot-sdk'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -50,3 +50,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime
           npm test
         timeout-minutes: 45
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Mock Your Runtime'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -50,3 +50,14 @@ jobs:
           cd polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing
           npm test
         timeout-minutes: 45
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Unit Test Pallets'
+      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing'
+    permissions:
+      issues: write
+      contents: read

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -65,3 +65,14 @@ jobs:
           cd polkadot-docs/parachains/set-up-parachain-template
           npm test
         timeout-minutes: 60
+
+  notify-failure:
+    needs: test
+    if: failure() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/notify-docs-failure.yml
+    with:
+      workflow_name: 'Set Up Parachain Template'
+      guide_path: 'polkadot-docs/parachains/set-up-parachain-template'
+    permissions:
+      issues: write
+      contents: read

--- a/polkadot-docs/MAINTAINERS
+++ b/polkadot-docs/MAINTAINERS
@@ -1,0 +1,1 @@
+@brunopgalvao


### PR DESCRIPTION
## Summary

- Add `polkadot-docs/MAINTAINERS` file listing maintainers to notify on test failures
- Add reusable workflow `.github/workflows/notify-docs-failure.yml` that creates/updates GitHub issues
- Add `notify-failure` job to all 8 polkadot-docs workflows

When a polkadot-docs test fails on master, this will:
1. Check for an existing open issue with title `[Test Failure] <workflow_name>`
2. If exists: add a comment with the new failure details
3. If not: create a new issue with `test-failure` and `polkadot-docs` labels, mentioning maintainers

## Test plan

- [x] Merge to master
- [x] Manually trigger a workflow and let it fail (or temporarily break a test)
- [ ] Verify issue is created with correct content and maintainer mention
- [ ] Trigger again - verify comment is added instead of duplicate issue