### PR TITLE
chore: sync Cargo.lock with v0.10.1 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1421,7 +1421,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "cliclack",


### PR DESCRIPTION
## Summary
- Fixes the release CI failure for v0.10.1
- Updates `Cargo.lock` to reflect the version bump from PR #84
- PR #84 updated `Cargo.toml` files but didn't include the lock file update, causing `--locked` builds to fail

## Test plan
- [ ] CI passes with `--locked` flag