### PR TITLE
chore(release): trigger fresh v0.10.1 release build

### DIFF
--- a/.github/releases/v0.10.1/RELEASE_NOTES.md
+++ b/.github/releases/v0.10.1/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Released: 2026-02-04
 ### Changes
 
 - Fix CLI version and automate version bumping (#83) (65a7cc2)
+- Sync Cargo.lock with version bump (#85) (f3fe8c4)
 
 
 ## Compatibility


### PR DESCRIPTION
Updates release notes to trigger fresh workflow run with fixed Cargo.lock.