### PR TITLE
ci: change polkadot-docs schedule to weekly on Sundays

### DIFF
--- a/.github/workflows/polkadot-docs-scheduled.yml
+++ b/.github/workflows/polkadot-docs-scheduled.yml
@@ -2,7 +2,7 @@ name: Scheduled Polkadot Docs Tests
 
 on:
   schedule:
-    - cron: '0 0 * * *'  # Daily at 00:00 UTC
+    - cron: '0 15 * * 0'  # Weekly on Sunday at 15:00 UTC (10:00 PM Bangkok)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Changes scheduled docs tests from daily to weekly
- Runs on Sundays at 10:00 PM Bangkok time (15:00 UTC)

Daily was overkill for catching upstream dependency changes.