### PR TITLE
ci: add auto PR description workflow

### DIFF
--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -1,0 +1,67 @@
+name: Auto PR Description
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  generate-description:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate PR description comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Check if PR already has a meaningful description
+            const body = (pr.body || '').trim();
+            if (body.length >= 10) {
+              console.log(`PR already has a description (${body.length} chars), skipping.`);
+              return;
+            }
+
+            console.log(`PR body is empty or minimal (${body.length} chars), generating description...`);
+
+            // Fetch commits in this PR
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            // Build commits list
+            let commitsList = '';
+            for (const commit of commits.data) {
+              const sha = commit.sha.substring(0, 7);
+              const firstLine = commit.commit.message.split('\n')[0];
+              commitsList += `- \`${sha}\` ${firstLine}\n`;
+            }
+
+            // Build the comment
+            const commentBody = [
+              'Update your PR with a well-documented description.',
+              '',
+              '**Commits:**',
+              '',
+              commitsList.trim(),
+            ].join('\n');
+
+            // Post comment
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: commentBody,
+            });
+
+            console.log('Posted PR description comment.');


### PR DESCRIPTION
## Summary

- Adds a workflow that posts a comment when a PR is opened without a description (< 10 chars)
- Comment nudges the author to add context and lists the PR's commits for reference
- Triggers only on `opened` events to avoid re-posting on edits or pushes
- Uses `actions/github-script` with commit-based analysis — no AI, no secrets, deterministic

## Test plan

- [x] Opened test PRs without a description — bot posted the expected comment
- [x] Verified PRs with a description are skipped (early exit on body >= 10 chars)