### PR TITLE
docs: clarify that cookbook recipes are test harnesses for external repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ Thank you for your interest in contributing! The easiest way to contribute a rec
 
 </div>
 
+> **Key concept:** Recipe source code lives in **your own GitHub repository**, not in this cookbook. The cookbook's `recipes/` directory contains only **test harnesses** that clone, build, and verify your external repo. A cookbook contribution = adding a test harness that points to your repo.
+
 <hr />
 
 ## Quick Start
@@ -193,7 +195,7 @@ test(my-recipe): add integration tests
 ## Getting Help
 
 - **Questions**: [Open an issue](https://github.com/polkadot-developers/polkadot-cookbook/issues)
-- **Example Projects**: See `recipes/` directory for reference implementations
+- **Example Test Harnesses**: See `recipes/` directory for test harness examples (each one clones and verifies an external recipe repo)
 
 <hr />
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,16 @@ Build runtime logic, smart contracts, dApps, and cross-chain applications with w
 
 The Polkadot Cookbook provides recipes across 5 pathways of Polkadot development:
 
+> **How it works:** Each recipe's source code lives in its own **external GitHub repository**. The `recipes/` directory here contains **test harnesses** that automatically clone, build, and verify each recipe.
+
 ### <img src=".github/media/icons/runtime-dark.svg#gh-dark-mode-only" width="20" height="20" alt="" /> <img src=".github/media/icons/runtime-light.svg#gh-light-mode-only" width="20" height="20" alt="" /> Pallets
 
 Build custom parachains with FRAME pallets, runtime logic, and PAPI integration testing.
 
 | Recipe | Description |
 |----------|-------------|
-| [**parachain-example**](recipes/parachains/parachain-example) | Full parachain development environment with 12+ pallets, custom logic, and TypeScript tests |
-| [**pallet-example**](recipes/pallets/pallet-example) | Pallet-only development (no runtime) for advanced users |
+| [**parachain-example**](recipes/parachains/parachain-example) | Verifies [recipe-parachain-example](https://github.com/brunopgalvao/recipe-parachain-example) -- full parachain with 12+ pallets, custom logic, and TypeScript tests |
+| [**pallet-example**](recipes/pallets/pallet-example) | Verifies [recipe-pallet-example](https://github.com/brunopgalvao/recipe-pallet-example) -- pallet-only development (no runtime) for advanced users |
 
 ### <img src=".github/media/icons/contracts-dark.svg#gh-dark-mode-only" width="20" height="20" alt="" /> <img src=".github/media/icons/contracts-light.svg#gh-light-mode-only" width="20" height="20" alt="" /> Contracts
 
@@ -50,7 +52,7 @@ Deploy and interact with Solidity smart contracts on Polkadot parachains.
 
 | Recipe | Description |
 |----------|-------------|
-| [**contracts-example**](recipes/contracts/contracts-example) | Template for Solidity contracts with Hardhat and deployment scripts |
+| [**contracts-example**](recipes/contracts/contracts-example) | Verifies [recipe-contracts-example](https://github.com/brunopgalvao/recipe-contracts-example) -- Solidity contracts with Hardhat and deployment scripts |
 
 ### <img src=".github/media/icons/interactions-dark.svg#gh-dark-mode-only" width="20" height="20" alt="" /> <img src=".github/media/icons/interactions-light.svg#gh-light-mode-only" width="20" height="20" alt="" /> Transactions
 
@@ -58,7 +60,7 @@ Single-chain transaction submission and state queries using the Polkadot API.
 
 | Recipe | Description |
 |----------|-------------|
-| [**transaction-example**](recipes/transactions/transaction-example) | Template for chain interactions with Polkadot API (TypeScript) |
+| [**transaction-example**](recipes/transactions/transaction-example) | Verifies [recipe-transaction-example](https://github.com/brunopgalvao/recipe-transaction-example) -- chain interactions with Polkadot API (TypeScript) |
 
 ### <img src=".github/media/icons/xcm-dark.svg#gh-dark-mode-only" width="20" height="20" alt="" /> <img src=".github/media/icons/xcm-light.svg#gh-light-mode-only" width="20" height="20" alt="" /> XCM
 
@@ -66,7 +68,7 @@ Cross-chain asset transfers and messaging between parachains.
 
 | Recipe | Description |
 |----------|-------------|
-| [**cross-chain-transaction-example**](recipes/cross-chain-transactions/cross-chain-transaction-example) | Template for XCM messaging with Chopsticks local testing |
+| [**cross-chain-transaction-example**](recipes/cross-chain-transactions/cross-chain-transaction-example) | Verifies [recipe-xcm-example](https://github.com/brunopgalvao/recipe-xcm-example) -- XCM messaging with Chopsticks local testing |
 
 ### <img src=".github/media/icons/testing-dark.svg#gh-dark-mode-only" width="20" height="20" alt="" /> <img src=".github/media/icons/testing-light.svg#gh-light-mode-only" width="20" height="20" alt="" /> Networks
 
@@ -74,9 +76,7 @@ Testing infrastructure with Zombienet and Chopsticks for local network developme
 
 | Recipe | Description |
 |----------|-------------|
-| [**network-example**](recipes/networks/network-example) | Template for Zombienet and Chopsticks network configurations |
-
-> **Note:** Each recipe lives in its own external GitHub repository. The `recipes/` directory contains test harnesses that automatically clone, build, and verify each recipe.
+| [**network-example**](recipes/networks/network-example) | Verifies [recipe-network-example](https://github.com/brunopgalvao/recipe-network-example) -- Zombienet and Chopsticks network configurations |
 
 > <img src=".github/media/icons/idea-dark.svg#gh-dark-mode-only" width="18" height="18" alt="" /> <img src=".github/media/icons/idea-light.svg#gh-light-mode-only" width="18" height="18" alt="" /> **Want to share your knowledge?** See [Contributing a Recipe](CONTRIBUTING.md)
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -2,6 +2,8 @@
 
 This section contains everything you need to know about contributing recipes to the Polkadot Cookbook.
 
+> **How recipes work:** Recipe source code lives in **your own GitHub repository**. The cookbook's `recipes/` directory contains only **test harnesses** that clone, build, and verify each external recipe repo. Contributing a recipe means adding a test harness that points to your repo.
+
 ## Documentation
 
 ### Essential Guides

--- a/docs/contributors/recipe-development.md
+++ b/docs/contributors/recipe-development.md
@@ -2,6 +2,8 @@
 
 Best practices and advanced techniques for developing high-quality recipes.
 
+> **Scope:** This guide covers developing your recipe's source code in **your own repository**. For adding the test harness to the cookbook, see the [Workflow Guide](workflow.md).
+
 ## Table of Contents
 
 - [Development Environment](#development-environment)
@@ -57,17 +59,24 @@ npm install -g typescript vitest
 
 ### Workspace Setup
 
+**Your recipe project** (in your own repo, outside the cookbook):
+
 ```bash
-# Clone and setup
+# Scaffold a new project
+dot create
+
+# Develop and test locally
+cd my-recipe
+npm install  # or cargo build
+npm test
+```
+
+**Cookbook fork** (for adding your test harness later):
+
+```bash
 git clone https://github.com/YOUR_USERNAME/polkadot-cookbook.git
 cd polkadot-cookbook
-
-# Add upstream
 git remote add upstream https://github.com/polkadot-developers/polkadot-cookbook.git
-
-# Install dependencies
-cd recipes/your-recipe
-npm install  # or cargo build
 ```
 
 ---

--- a/docs/contributors/recipe-guidelines.md
+++ b/docs/contributors/recipe-guidelines.md
@@ -2,6 +2,8 @@
 
 Standards and best practices for creating high-quality Polkadot Cookbook recipes.
 
+> **Important:** This guide covers quality standards for two things: **(1)** your **external recipe repository** and **(2)** the **test harness** you add to the cookbook. The cookbook itself only contains test harnesses -- recipe source code lives in your own GitHub repository.
+
 ## Table of Contents
 
 - [Recipe Structure](#recipe-structure)
@@ -16,39 +18,35 @@ Standards and best practices for creating high-quality Polkadot Cookbook recipes
 
 ## Recipe Structure
 
-### Required Files
+### What Goes in the Cookbook (Test Harness)
 
-Every recipe must include:
-
-```
-recipes/your-recipe/
-├── README.md              # Main content with frontmatter metadata (REQUIRED)
-├── src/                   # Source code (REQUIRED for code recipes)
-└── tests/                 # Tests (REQUIRED)
-```
-
-**Note:** Recipe metadata (title, description) is read from README.md frontmatter. The `recipe.config.yml` file is deprecated.
-
-### Optional Files
-
-Include when appropriate:
+Your cookbook contribution is a **test harness** -- a lightweight directory under `recipes/{pathway}/{your-recipe}/` that clones, builds, and verifies your external repo. It does **not** contain recipe source code.
 
 ```
-recipes/your-recipe/
-├── package.json           # npm dependencies (TypeScript)
+recipes/{pathway}/{your-recipe}/
+├── package.json           # vitest + @types/node + typescript
+├── package-lock.json      # Locked dependencies
+├── vitest.config.ts       # Vitest config
 ├── tsconfig.json          # TypeScript config
-├── vitest.config.ts       # Test config
-├── Cargo.toml             # Rust dependencies
-├── hardhat.config.ts      # Hardhat config (Solidity)
-├── scripts/               # Helper scripts
-└── assets/                # Images, diagrams
+├── .gitignore             # Ignore cloned repo dir, node_modules
+├── README.md              # Description + link to external repo (with frontmatter)
+└── tests/
+    └── recipe.test.ts     # Clone → install → build → test
 ```
+
+Use an existing test harness as a template (e.g., [`recipes/contracts/contracts-example/`](../../recipes/contracts/contracts-example/)).
+
+### What Goes in Your External Repository
+
+Your recipe's source code, dependencies, and tests live in **your own GitHub repository**. The structure depends on the recipe type (see [Type-Specific Structure](#type-specific-structure) below).
 
 ### Type-Specific Structure
 
+The structures below describe **your external repository** -- the recipe project you host on your own GitHub. This code does **not** go into the cookbook (the cookbook only gets a test harness).
+
 **Polkadot SDK (Rust):**
 ```
-recipes/your-recipe/
+your-external-repo/
 ├── README.md
 ├── Cargo.toml
 ├── src/
@@ -59,7 +57,7 @@ recipes/your-recipe/
 
 **Solidity Contracts:**
 ```
-recipes/your-recipe/
+your-external-repo/
 ├── README.md
 ├── package.json
 ├── hardhat.config.ts
@@ -73,7 +71,7 @@ recipes/your-recipe/
 
 **XCM Recipes:**
 ```
-recipes/your-recipe/
+your-external-repo/
 ├── README.md
 ├── package.json
 ├── chopsticks.yml         # Chopsticks config
@@ -85,7 +83,7 @@ recipes/your-recipe/
 
 **TypeScript Interaction:**
 ```
-recipes/your-recipe/
+your-external-repo/
 ├── README.md
 ├── package.json
 ├── tsconfig.json
@@ -100,6 +98,8 @@ recipes/your-recipe/
 ## Content Guidelines
 
 ### README.md Structure
+
+> **Note:** This section describes the README for **your external recipe repository**, not the short README in the cookbook test harness.
 
 Every recipe README must follow this structure:
 
@@ -694,14 +694,12 @@ Use consistent terminology:
 
 ## Checklist
 
-Before submitting your recipe, verify:
+Before submitting, verify both your external repository and your cookbook test harness:
 
-### Structure
+### Your External Repository
 - [ ] README.md exists with frontmatter (title, description)
 - [ ] src/ directory with implementation
 - [ ] tests/ directory with comprehensive tests
-
-### Content
 - [ ] Clear title and description
 - [ ] Prerequisites listed
 - [ ] Learning objectives defined
@@ -709,28 +707,29 @@ Before submitting your recipe, verify:
 - [ ] Complete code examples
 - [ ] Expected output shown
 - [ ] Troubleshooting section
-
-### Code Quality
 - [ ] Follows language style guide
 - [ ] Formatted (cargo fmt / prettier)
 - [ ] Linted (clippy / eslint)
 - [ ] Meaningful variable names
 - [ ] Proper error handling
 - [ ] Comments for complex logic
-
-### Testing
 - [ ] All code examples tested manually
 - [ ] Automated tests pass
 - [ ] Edge cases covered
 - [ ] Error cases tested
+- [ ] A version tag exists (e.g., `v1.0.0`)
 
-### Documentation
-- [ ] Code comments where needed
-- [ ] README is clear and complete
-- [ ] Links to external resources
-- [ ] No broken links
-
-### Validation
+### Your Cookbook Test Harness
+- [ ] Test harness directory created under `recipes/{pathway}/{your-recipe}/`
+- [ ] `package.json` with vitest, @types/node, typescript
+- [ ] `package-lock.json` committed
+- [ ] `vitest.config.ts` configured
+- [ ] `tsconfig.json` configured
+- [ ] `.gitignore` ignores cloned repo dir and node_modules
+- [ ] `README.md` links to external repo
+- [ ] `tests/recipe.test.ts` clones, installs, builds, and tests external repo
+- [ ] Version tag in test is pinned to an existing tag in external repo
+- [ ] `npm ci && npm test` passes locally
 - [ ] Pre-commit hooks pass
 - [ ] CI tests pass
 
@@ -738,15 +737,11 @@ Before submitting your recipe, verify:
 
 ## Examples
 
-Study these well-structured recipes:
+Study these existing test harnesses to see how they clone and verify external repos:
 
-- **Basic Pallet** - `recipes/basic-pallet/` - Simple, clear structure
-- **Storage Operations** - `recipes/storage-operations/` - Good code examples
-- **Events and Errors** - `recipes/events-and-errors/` - Comprehensive error handling
-
-Browse all recipes:
-```bash
-```
+- **Contracts** - [`recipes/contracts/contracts-example/`](../../recipes/contracts/contracts-example/) - Solidity contract test harness
+- **Parachain** - [`recipes/parachains/parachain-example/`](../../recipes/parachains/parachain-example/) - Full parachain test harness
+- **Transaction** - [`recipes/transactions/transaction-example/`](../../recipes/transactions/transaction-example/) - TypeScript interaction test harness
 
 ---
 

--- a/docs/contributors/testing-recipes.md
+++ b/docs/contributors/testing-recipes.md
@@ -2,6 +2,8 @@
 
 Comprehensive guide to testing Polkadot Cookbook recipes across all types.
 
+> **Scope:** This guide covers testing your recipe's source code in **your external repository**. For running the cookbook's test harnesses (which clone and verify external repos), see the [Workflow Guide](workflow.md#step-4-test-your-test-harness).
+
 ## Table of Contents
 
 - [Testing Philosophy](#testing-philosophy)

--- a/docs/contributors/workflow.md
+++ b/docs/contributors/workflow.md
@@ -78,7 +78,7 @@ git config --list
 
 ---
 
-## Step 2: Create a Test Harness
+## Step 2: Create a Test Harness (Your Cookbook Contribution)
 
 Each recipe in the cookbook is a test harness that clones and verifies an external repository. To add a new recipe, create a test harness directory.
 
@@ -170,7 +170,7 @@ source_repo: "https://github.com/YOUR_USERNAME/recipe-your-recipe"
 
 ---
 
-## Step 3: Develop Your Recipe
+## Step 3: Develop Your Recipe (In Your Own Repository)
 
 ### Recipe Code Lives in Your Own Repository
 


### PR DESCRIPTION
## Summary

- Makes it immediately obvious across all contributor-facing docs that recipe source code lives in **external GitHub repositories** and the cookbook's `recipes/` directory contains only **lightweight test harnesses**
- Adds architecture callouts to README.md, CONTRIBUTING.md, and all contributor guide pages
- Rewords recipe table descriptions in README.md to link directly to external repos
- Major rework of `recipe-guidelines.md`: replaces misleading "Required Files" section (which showed `src/` as required), splits checklist into "External Repository" vs "Cookbook Test Harness", fixes broken example references
- Adds scope notes to `recipe-development.md` and `testing-recipes.md` clarifying they cover your external repo
- Makes workflow step headings more explicit (e.g., "Create a Test Harness (Your Cookbook Contribution)")

## Test plan

- [x] Read through each modified file to verify messaging is consistent
- [x] Verify all external repo links (brunopgalvao/recipe-*) are correct
- [x] Confirm no useful content was lost, only restructured
- [x] Check that the test harness structure shown in docs matches the actual structure in `recipes/contracts/contracts-example/`