### PR TITLE
Release v0.11.0

### DIFF
--- a/.github/releases/v0.11.0/RELEASE_NOTES.md
+++ b/.github/releases/v0.11.0/RELEASE_NOTES.md
@@ -1,0 +1,35 @@
+# Release v0.11.0
+
+Released: 2026-02-12
+
+## Changes Since v0.10.1
+
+**Version Bump:** MINOR
+
+### Highlights
+
+- **SDK: clone + overlay architecture** — `dot create` now clones the upstream `polkadot-sdk-parachain-template` at a pinned git tag instead of embedding ~40 template files at compile time. Templates are cached at `~/.dot/templates/` after first clone. Updating to a new upstream version is now a 2-constant change. (#96)
+
+### Changes
+
+- feat(sdk): replace embedded template with clone + overlay (#96) (31f56ea)
+- ci: add auto PR description workflow (#100) (fbfc19d)
+- feat: add uniswap v2 core revm migration (#92) (98b53aa)
+- refactor: restructure recipes to test-only harnesses with external repos (#91) (748da67)
+- ci: change polkadot-docs schedule to weekly on Sundays (#88) (8386714)
+
+## Compatibility
+
+This release was tested with:
+- Rust: 1.91.0
+- Node.js: v24.7.0
+
+## Testing
+
+All recipes have passed CI tests.
+
+Full manifest: [manifest.yml](./manifest.yml)
+
+---
+
+**Status:** Alpha (v0.x.x)

--- a/.github/releases/v0.11.0/manifest.yml
+++ b/.github/releases/v0.11.0/manifest.yml
@@ -1,0 +1,27 @@
+release: v0.11.0
+release_date: 2026-02-12T12:00:00Z
+status: alpha
+
+tooling:
+  rust: "1.91.0"
+  node: "v24.7.0"
+
+recipes:
+  contracts-example:
+    path: "recipes/contracts/contracts-example"
+    tested: true
+  cross-chain-transaction-example:
+    path: "recipes/cross-chain-transactions/cross-chain-transaction-example"
+    tested: true
+  network-example:
+    path: "recipes/networks/network-example"
+    tested: true
+  pallet-example:
+    path: "recipes/pallets/pallet-example"
+    tested: true
+  parachain-example:
+    path: "recipes/parachains/parachain-example"
+    tested: true
+  transaction-example:
+    path: "recipes/transactions/transaction-example"
+    tested: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["dot/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Polkadot Cookbook Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v0.11.0

### Highlights

- **SDK: clone + overlay architecture** — `dot create` now clones the upstream `polkadot-sdk-parachain-template` at a pinned git tag instead of embedding ~40 template files at compile time. Templates are cached at `~/.dot/templates/` after first clone. Updating to a new upstream version is now a 2-constant change. (#96)

### Changes since v0.10.1

- feat(sdk): replace embedded template with clone + overlay (#96)
- ci: add auto PR description workflow (#100)
- feat: add uniswap v2 core revm migration (#92)
- refactor: restructure recipes to test-only harnesses with external repos (#91)
- ci: change polkadot-docs schedule to weekly on Sundays (#88)

### Version Bump

- **Type:** MINOR (new feature in alpha)
- **From:** v0.10.1 → **v0.11.0**
- Workspace version updated in `Cargo.toml` + `Cargo.lock`
- Release manifest and notes generated

### Next Steps

Once this PR is merged:
1. Tag `v0.11.0` on the merge commit
2. Create GitHub Release from the tag
3. Trigger CLI release workflow for `cli-v0.11.0` if desired