### PR TITLE
fix(ci): fetch tags in release workflow

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Get last release
         id: last_release
@@ -52,25 +53,21 @@ jobs:
           LAST_TAG: ${{ steps.last_release.outputs.last_tag }}
           FORCE_BUMP: ${{ github.event.inputs.version_bump }}
         run: |
-          # Get all merged PRs since last release
-          if [ "$LAST_TAG" = "v0.0.0" ]; then
-            echo "No previous release, this will be initial release"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "version_bump=minor" >> $GITHUB_OUTPUT
-            echo "new_version=v0.1.0" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          echo "has_changes=true" >> $GITHUB_OUTPUT
 
           # Get all commits since last tag (including squash-merged PRs)
-          ALL_COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"%s %b" || echo "")
+          if [ "$LAST_TAG" = "v0.0.0" ]; then
+            echo "No previous release tag found"
+            ALL_COMMITS=$(git log --pretty=format:"%s %b" || echo "")
+          else
+            ALL_COMMITS=$(git log $LAST_TAG..HEAD --pretty=format:"%s %b" || echo "")
+          fi
 
           if [ -z "$ALL_COMMITS" ]; then
             echo "No changes since last release"
             echo "has_changes=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-
-          echo "has_changes=true" >> $GITHUB_OUTPUT
 
           # Check for manual version bump override
           if [ "$FORCE_BUMP" != "auto" ] && [ -n "$FORCE_BUMP" ]; then


### PR DESCRIPTION
## Summary

- Adds `fetch-tags: true` to the checkout step in `release-weekly.yml` — without it, `git describe --tags` finds no tags and falls back to `v0.0.0`
- Removes the `v0.0.0` early-exit path that hardcoded `v0.1.0` and skipped the manual `version_bump` input entirely

## Context

When triggering the workflow manually with `version_bump=minor`, it produced `v0.1.0` instead of `v0.11.0` because:
1. Tags weren't fetched, so last tag resolved to `v0.0.0`
2. The `v0.0.0` branch exited before checking the `FORCE_BUMP` override

## Test plan

- [ ] Merge this PR, then re-trigger `release-weekly.yml` with `version_bump=minor`
- [ ] Verify it detects `v0.10.1` as the last tag and computes `v0.11.0`