### PR TITLE
fix(ci): use explicit git fetch --tags for reliable tag detection

### DIFF
--- a/.github/workflows/release-on-breaking-change.yml
+++ b/.github/workflows/release-on-breaking-change.yml
@@ -256,6 +256,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -37,7 +37,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
 
       - name: Get last release
         id: last_release


### PR DESCRIPTION
## Summary

- Replaces `fetch-tags: true` with an explicit `git fetch --tags --force` step after checkout
- Fixes both `release-weekly.yml` and `release-on-breaking-change.yml`

## Root cause

`actions/checkout@v4` has a [known bug](https://github.com/actions/checkout/issues/1471) where `fetch-tags: true` is a no-op. Additionally, the action [overwrites annotated tags with lightweight tags](https://github.com/actions/checkout/issues/882), causing `git describe --tags` to fail to find them.

This is why the release workflow computed `v0.0.0` as the last tag and created a `v0.1.0` release PR instead of `v0.11.0`.

## Fix

An explicit `git fetch --tags --force` after checkout reliably restores all tags (including annotated ones), making `git describe` work correctly.

## Test plan

- [ ] Merge, then trigger `release-weekly.yml` manually and verify "Get last release" step finds the correct tag