### PR TITLE
ci: add caching for parachain template builds, polkadot tools, and zombienet

### DIFF
--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -31,20 +31,49 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Cache polkadot tools
+        uses: actions/cache@v4
+        id: cache-polkadot-tools
+        with:
+          path: ~/.local/bin
+          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+
       - name: Install required tools
         run: |
-          RELEASE_TAG="polkadot-stable2512-1"
-          BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
-          curl -L -o chain-spec-builder "${BASE_URL}/chain-spec-builder"
-          curl -L -o polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
-          chmod +x chain-spec-builder polkadot-omni-node
-          sudo mv chain-spec-builder polkadot-omni-node /usr/local/bin/
+          mkdir -p ~/.local/bin
+          if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
+            RELEASE_TAG="polkadot-stable2512-1"
+            BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
+            curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
+            curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
+            chmod +x ~/.local/bin/chain-spec-builder ~/.local/bin/polkadot-omni-node
+          fi
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify polkadot tools
+        run: |
           chain-spec-builder --version
           polkadot-omni-node --version
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/add-existing-pallets/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-latest-${{ hashFiles('polkadot-docs/parachains/customize-runtime/add-existing-pallets/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/add-existing-pallets/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -31,20 +31,49 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Cache polkadot tools
+        uses: actions/cache@v4
+        id: cache-polkadot-tools
+        with:
+          path: ~/.local/bin
+          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+
       - name: Install required tools
         run: |
-          RELEASE_TAG="polkadot-stable2512-1"
-          BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
-          curl -L -o chain-spec-builder "${BASE_URL}/chain-spec-builder"
-          curl -L -o polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
-          chmod +x chain-spec-builder polkadot-omni-node
-          sudo mv chain-spec-builder polkadot-omni-node /usr/local/bin/
+          mkdir -p ~/.local/bin
+          if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
+            RELEASE_TAG="polkadot-stable2512-1"
+            BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
+            curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
+            curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
+            chmod +x ~/.local/bin/chain-spec-builder ~/.local/bin/polkadot-omni-node
+          fi
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify polkadot tools
+        run: |
           chain-spec-builder --version
           polkadot-omni-node --version
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/add-pallet-instances/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/add-pallet-instances/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/add-pallet-instances/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -36,9 +36,25 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -31,20 +31,49 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Cache polkadot tools
+        uses: actions/cache@v4
+        id: cache-polkadot-tools
+        with:
+          path: ~/.local/bin
+          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+
       - name: Install required tools
         run: |
-          RELEASE_TAG="polkadot-stable2512-1"
-          BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
-          curl -L -o chain-spec-builder "${BASE_URL}/chain-spec-builder"
-          curl -L -o polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
-          chmod +x chain-spec-builder polkadot-omni-node
-          sudo mv chain-spec-builder polkadot-omni-node /usr/local/bin/
+          mkdir -p ~/.local/bin
+          if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
+            RELEASE_TAG="polkadot-stable2512-1"
+            BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
+            curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
+            curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
+            chmod +x ~/.local/bin/chain-spec-builder ~/.local/bin/polkadot-omni-node
+          fi
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify polkadot tools
+        run: |
           chain-spec-builder --version
           polkadot-omni-node --version
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -32,6 +32,16 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang make
 
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Install npm dependencies
         run: |
           cd polkadot-docs/parachains/install-polkadot-sdk

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -36,9 +36,25 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -36,9 +36,25 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -27,13 +27,24 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler clang libclang-dev make
 
+      - name: Cache Zombienet
+        uses: actions/cache@v4
+        id: cache-zombienet
+        with:
+          path: ~/.local/bin/zombienet
+          key: ${{ runner.os }}-zombienet-v1.3.138
+
       - name: Install Zombienet
         run: |
-          ZOMBIENET_VERSION="v1.3.138"
-          curl -L -o zombienet https://github.com/paritytech/zombienet/releases/download/${ZOMBIENET_VERSION}/zombienet-linux-x64
-          chmod +x zombienet
-          sudo mv zombienet /usr/local/bin/
-          zombienet version
+          mkdir -p ~/.local/bin
+          if [ "${{ steps.cache-zombienet.outputs.cache-hit }}" != "true" ]; then
+            curl -L -o ~/.local/bin/zombienet https://github.com/paritytech/zombienet/releases/download/v1.3.138/zombienet-linux-x64
+            chmod +x ~/.local/bin/zombienet
+          fi
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify Zombienet
+        run: zombienet version
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -45,13 +56,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
-      - name: Cache cargo build
+      - name: Cache parachain template build
         uses: actions/cache@v4
+        id: cache-parachain-template
         with:
-          path: polkadot-docs/networks/run-a-parachain-network/polkadot-runtime-templates/generic-template/target
-          key: ${{ runner.os }}-cargo-build-parachain-${{ hashFiles('polkadot-docs/networks/run-a-parachain-network/rust-toolchain.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-parachain-
+          path: polkadot-docs/networks/run-a-parachain-network/polkadot-sdk-parachain-template
+          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/networks/run-a-parachain-network/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/networks/run-a-parachain-network/polkadot-sdk-parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -31,20 +31,49 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      - name: Cache polkadot tools
+        uses: actions/cache@v4
+        id: cache-polkadot-tools
+        with:
+          path: ~/.local/bin
+          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+
       - name: Install required tools
         run: |
-          RELEASE_TAG="polkadot-stable2512-1"
-          BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
-          curl -L -o chain-spec-builder "${BASE_URL}/chain-spec-builder"
-          curl -L -o polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
-          chmod +x chain-spec-builder polkadot-omni-node
-          sudo mv chain-spec-builder polkadot-omni-node /usr/local/bin/
+          mkdir -p ~/.local/bin
+          if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
+            RELEASE_TAG="polkadot-stable2512-1"
+            BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
+            curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
+            curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
+            chmod +x ~/.local/bin/chain-spec-builder ~/.local/bin/polkadot-omni-node
+          fi
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Verify polkadot tools
+        run: |
           chain-spec-builder --version
           polkadot-omni-node --version
+
+      - name: Cache parachain template build
+        uses: actions/cache@v4
+        id: cache-parachain-template
+        with:
+          path: polkadot-docs/parachains/set-up-parachain-template/.test-workspace/parachain-template
+          key: ${{ runner.os }}-parachain-template-latest-${{ hashFiles('polkadot-docs/parachains/set-up-parachain-template/rust-toolchain.toml') }}
+
+      - name: Clean cached template for fresh test
+        if: steps.cache-parachain-template.outputs.cache-hit == 'true'
+        run: |
+          cd polkadot-docs/parachains/set-up-parachain-template/.test-workspace/parachain-template
+          git checkout -- .
+          git clean -fd -e target/
 
       - name: Install npm dependencies
         run: |


### PR DESCRIPTION
## Summary

- **Cache parachain template clone + build** across 8 workflows — on cache hit, `git checkout -- . && git clean -fd -e target/` resets modifications while preserving compiled `target/`, reducing rebuild from ~30-45 min to ~5 min
- **Cache polkadot tools** (`polkadot-omni-node`, `chain-spec-builder`) in 4 workflows — skip download on cache hit
- **Cache Zombienet** binary in `run-a-parachain-network` — skip download on cache hit
- **Add cargo registry cache** to `install-polkadot-sdk` (previously had none)
- **Add `restore-keys`** to 7 existing cargo caches — enables partial cache hits when `Cargo.lock` changes
- **Fix stale cache path** in `run-a-parachain-network` — was caching `polkadot-runtime-templates/generic-template/target` (doesn't exist), now caches the correct `polkadot-sdk-parachain-template` directory

## Test plan

- [ ] Trigger a workflow via `workflow_dispatch` (e.g., `Create a Custom Pallet`) — first run builds from scratch and populates cache
- [ ] Trigger the same workflow again — verify cache hit, git cleanup succeeds, and only modified crates recompile
- [ ] Verify polkadot tools cache hit skips binary download
- [ ] Check GitHub Actions cache tab for expected cache entries