### PR TITLE
refactor: centralize dependency versions with versions.yml

### DIFF
--- a/.github/scripts/sync-versions.sh
+++ b/.github/scripts/sync-versions.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync versions from polkadot-docs upstream variables.yml into cookbook versions.yml.
+# Only updates if upstream is strictly newer — never downgrades.
+
+UPSTREAM_URL="https://raw.githubusercontent.com/polkadot-developers/polkadot-docs/master/variables.yml"
+LOCAL_FILE="versions.yml"
+UPSTREAM_FILE="/tmp/upstream-variables.yml"
+
+curl -sSf "$UPSTREAM_URL" -o "$UPSTREAM_FILE"
+
+CHANGELOG=""
+HAS_UPDATES=false
+
+# Compare two version strings.  Returns 0 if $2 > $1 (upstream is newer).
+# Handles semver (v0.0.5, 0.13.0) and polkadot-sdk tags (polkadot-stable2512-1).
+is_upstream_newer() {
+  local local_ver="$1"
+  local upstream_ver="$2"
+
+  # Strip leading 'v' for comparison
+  local lv="${local_ver#v}"
+  local uv="${upstream_ver#v}"
+
+  # For polkadot-stable tags: extract YYMM-patch portion
+  if [[ "$lv" == polkadot-stable* ]]; then
+    lv="${lv#polkadot-stable}"
+    uv="${uv#polkadot-stable}"
+    # Convert e.g. 2512-1 to 2512.1 for sort -V
+    lv="${lv//-/.}"
+    uv="${uv//-/.}"
+  fi
+
+  if [ "$lv" = "$uv" ]; then
+    return 1  # same version
+  fi
+
+  # sort -V puts the smaller version first
+  local smaller
+  smaller=$(printf '%s\n%s\n' "$lv" "$uv" | sort -V | head -n1)
+  if [ "$smaller" = "$lv" ]; then
+    return 0  # upstream is newer
+  else
+    return 1  # local is newer or equal
+  fi
+}
+
+# Update a single version entry if upstream is newer.
+# Arguments: description, local yq path, upstream yq path
+check_and_update() {
+  local desc="$1"
+  local local_path="$2"
+  local upstream_path="$3"
+
+  local local_ver
+  local upstream_ver
+
+  local_ver=$(yq "$local_path" "$LOCAL_FILE" 2>/dev/null || echo "null")
+  upstream_ver=$(yq "$upstream_path" "$UPSTREAM_FILE" 2>/dev/null || echo "null")
+
+  if [ "$local_ver" = "null" ] || [ "$upstream_ver" = "null" ]; then
+    echo "SKIP $desc: local=$local_ver upstream=$upstream_ver"
+    return
+  fi
+
+  echo "CHECK $desc: local=$local_ver upstream=$upstream_ver"
+
+  if is_upstream_newer "$local_ver" "$upstream_ver"; then
+    echo "  -> Updating $desc: $local_ver -> $upstream_ver"
+    yq -i "$local_path = \"$upstream_ver\"" "$LOCAL_FILE"
+    CHANGELOG="${CHANGELOG}- **${desc}**: \`${local_ver}\` -> \`${upstream_ver}\`\n"
+    HAS_UPDATES=true
+  else
+    echo "  -> Up to date (or ahead)"
+  fi
+}
+
+# Define version mappings: cookbook path <-> upstream path
+check_and_update \
+  "Polkadot SDK" \
+  ".polkadot_sdk.release_tag" \
+  ".dependencies.repositories.polkadot_sdk.version"
+
+check_and_update \
+  "Parachain Template" \
+  ".parachain_template.version" \
+  ".dependencies.repositories.polkadot_sdk_parachain_template.version"
+
+check_and_update \
+  "Polkadot Omni Node" \
+  ".parachain_template.crates.polkadot_omni_node.version" \
+  ".dependencies.crates.polkadot_omni_node.version"
+
+check_and_update \
+  "Chain Spec Builder" \
+  ".parachain_template.crates.chain_spec_builder.version" \
+  ".dependencies.repositories.polkadot_sdk_parachain_template.subdependencies.chain_spec_builder_version"
+
+check_and_update \
+  "Zombienet" \
+  ".zombienet.version" \
+  ".dependencies.repositories.zombienet.version"
+
+# Set outputs for the workflow
+if [ "$HAS_UPDATES" = true ]; then
+  echo "has_updates=true" >> "$GITHUB_OUTPUT"
+  {
+    echo "changelog<<EOF"
+    echo -e "$CHANGELOG"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+else
+  echo "has_updates=false" >> "$GITHUB_OUTPUT"
+fi
+
+echo ""
+echo "Done. has_updates=$HAS_UPDATES"

--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -3,9 +3,13 @@ name: Add Existing Pallets
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/add-existing-pallets/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/add-existing-pallets/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/add-existing-pallets/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/add-existing-pallets/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -42,13 +51,13 @@ jobs:
         id: cache-polkadot-tools
         with:
           path: ~/.local/bin
-          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+          key: ${{ runner.os }}-polkadot-tools-${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
       - name: Install required tools
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
-            RELEASE_TAG="polkadot-stable2512-1"
+            RELEASE_TAG="${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}"
             BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
             curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
             curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -3,9 +3,13 @@ name: Add Pallet Instances
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/add-pallet-instances/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/add-pallet-instances/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/add-pallet-instances/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/add-pallet-instances/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -42,13 +52,13 @@ jobs:
         id: cache-polkadot-tools
         with:
           path: ~/.local/bin
-          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+          key: ${{ runner.os }}-polkadot-tools-${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
       - name: Install required tools
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
-            RELEASE_TAG="polkadot-stable2512-1"
+            RELEASE_TAG="${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}"
             BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
             curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
             curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
@@ -66,7 +76,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/parachains/customize-runtime/add-pallet-instances/.test-workspace/parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/add-pallet-instances/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/parachains/customize-runtime/add-pallet-instances/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -3,9 +3,13 @@ name: Benchmark Pallets
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -47,7 +56,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/.test-workspace/parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -3,9 +3,13 @@ name: Create a Custom Pallet
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -42,13 +52,13 @@ jobs:
         id: cache-polkadot-tools
         with:
           path: ~/.local/bin
-          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+          key: ${{ runner.os }}-polkadot-tools-${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
       - name: Install required tools
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
-            RELEASE_TAG="polkadot-stable2512-1"
+            RELEASE_TAG="${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}"
             BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
             curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
             curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"
@@ -66,7 +76,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/.test-workspace/parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -3,9 +3,13 @@ name: Install Polkadot SDK
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/install-polkadot-sdk/**']
+    paths:
+      - 'polkadot-docs/parachains/install-polkadot-sdk/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/install-polkadot-sdk/**']
+    paths:
+      - 'polkadot-docs/parachains/install-polkadot-sdk/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -3,9 +3,13 @@ name: Mock Your Runtime
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -47,7 +56,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/.test-workspace/parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -3,9 +3,13 @@ name: Unit Test Pallets
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/**']
+    paths:
+      - 'polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -47,7 +56,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/.test-workspace/parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -3,9 +3,13 @@ name: Run a Parachain Network
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/networks/run-a-parachain-network/**']
+    paths:
+      - 'polkadot-docs/networks/run-a-parachain-network/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/networks/run-a-parachain-network/**']
+    paths:
+      - 'polkadot-docs/networks/run-a-parachain-network/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
+          echo "ZOMBIENET_VERSION=$(yq '.zombienet.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -32,13 +42,13 @@ jobs:
         id: cache-zombienet
         with:
           path: ~/.local/bin/zombienet
-          key: ${{ runner.os }}-zombienet-v1.3.138
+          key: ${{ runner.os }}-zombienet-${{ steps.versions.outputs.ZOMBIENET_VERSION }}
 
       - name: Install Zombienet
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.cache-zombienet.outputs.cache-hit }}" != "true" ]; then
-            curl -L -o ~/.local/bin/zombienet https://github.com/paritytech/zombienet/releases/download/v1.3.138/zombienet-linux-x64
+            curl -L -o ~/.local/bin/zombienet https://github.com/paritytech/zombienet/releases/download/${{ steps.versions.outputs.ZOMBIENET_VERSION }}/zombienet-linux-x64
             chmod +x ~/.local/bin/zombienet
           fi
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -61,7 +71,7 @@ jobs:
         id: cache-parachain-template
         with:
           path: polkadot-docs/networks/run-a-parachain-network/polkadot-sdk-parachain-template
-          key: ${{ runner.os }}-parachain-template-v0.0.5-${{ hashFiles('polkadot-docs/networks/run-a-parachain-network/rust-toolchain.toml') }}
+          key: ${{ runner.os }}-parachain-template-${{ steps.versions.outputs.TEMPLATE_VERSION }}-${{ hashFiles('polkadot-docs/networks/run-a-parachain-network/rust-toolchain.toml') }}
 
       - name: Clean cached template for fresh test
         if: steps.cache-parachain-template.outputs.cache-hit == 'true'

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -3,9 +3,13 @@ name: Set Up Parachain Template
 on:
   push:
     branches: [master]
-    paths: ['polkadot-docs/parachains/set-up-parachain-template/**']
+    paths:
+      - 'polkadot-docs/parachains/set-up-parachain-template/**'
+      - 'versions.yml'
   pull_request:
-    paths: ['polkadot-docs/parachains/set-up-parachain-template/**']
+    paths:
+      - 'polkadot-docs/parachains/set-up-parachain-template/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -14,6 +18,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
+          echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -42,13 +52,13 @@ jobs:
         id: cache-polkadot-tools
         with:
           path: ~/.local/bin
-          key: ${{ runner.os }}-polkadot-tools-polkadot-stable2512-1
+          key: ${{ runner.os }}-polkadot-tools-${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
       - name: Install required tools
         run: |
           mkdir -p ~/.local/bin
           if [ "${{ steps.cache-polkadot-tools.outputs.cache-hit }}" != "true" ]; then
-            RELEASE_TAG="polkadot-stable2512-1"
+            RELEASE_TAG="${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}"
             BASE_URL="https://github.com/paritytech/polkadot-sdk/releases/download/${RELEASE_TAG}"
             curl -L -o ~/.local/bin/chain-spec-builder "${BASE_URL}/chain-spec-builder"
             curl -L -o ~/.local/bin/polkadot-omni-node "${BASE_URL}/polkadot-omni-node"

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -1,0 +1,65 @@
+name: Sync Dependency Versions
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for existing sync PR
+        id: check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN_PRS=$(gh pr list --label sync-versions --state open --json number --jq 'length')
+          if [ "$OPEN_PRS" -gt 0 ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "An open sync-versions PR already exists, skipping."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Sync versions from upstream
+        if: steps.check-pr.outputs.exists == 'false'
+        id: sync
+        run: bash .github/scripts/sync-versions.sh
+
+      - name: Create PR for version updates
+        if: steps.check-pr.outputs.exists == 'false' && steps.sync.outputs.has_updates == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="chore/sync-versions-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git add versions.yml
+          git commit -m "chore: sync dependency versions from polkadot-docs"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore: sync dependency versions from polkadot-docs" \
+            --label "sync-versions" \
+            --body "$(cat <<'PREOF'
+          ## Dependency Version Sync
+
+          Automated sync from [polkadot-docs variables.yml](https://github.com/polkadot-developers/polkadot-docs/blob/master/variables.yml).
+
+          ### Changes
+
+          ${{ steps.sync.outputs.changelog }}
+
+          > Only versions where upstream is strictly newer are updated. Cookbook-ahead versions are left untouched.
+
+          ### Verification
+
+          All `polkadot-docs-*` workflows will run automatically via the `versions.yml` path trigger.
+          PREOF
+          )"

--- a/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts
+++ b/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts
@@ -5,10 +5,10 @@ import { join } from "path";
 
 const PROJECT_DIR = process.cwd();
 const TEMPLATE_REPO = "https://github.com/paritytech/polkadot-sdk-parachain-template";
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const TEMPLATE_DIR = join(PROJECT_DIR, "polkadot-sdk-parachain-template");
 const BIN_DIR = join(PROJECT_DIR, "bin");
-const POLKADOT_VERSION = "polkadot-stable2512-1";
+const POLKADOT_VERSION = process.env.POLKADOT_SDK_VERSION!;
 const POLKADOT_RELEASE_URL = `https://github.com/paritytech/polkadot-sdk/releases/download/${POLKADOT_VERSION}`;
 const POLKADOT_BINARY = join(BIN_DIR, "polkadot");
 const POLKADOT_PREPARE_WORKER = join(BIN_DIR, "polkadot-prepare-worker");

--- a/polkadot-docs/networks/run-a-parachain-network/vitest.config.ts
+++ b/polkadot-docs/networks/run-a-parachain-network/vitest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+      POLKADOT_SDK_VERSION: vars.POLKADOT_SDK_VERSION,
+    },
     // Run test FILES sequentially (critical - build depends on clone, spawn depends on build)
     fileParallelism: false,
     // Run tests within files sequentially

--- a/polkadot-docs/parachains/customize-runtime/add-existing-pallets/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/add-existing-pallets/tests/guide.test.ts
@@ -58,7 +58,7 @@ describe("Add Existing Pallets Guide", () => {
         console.log(`chain-spec-builder: ${result.trim()}`);
       } catch (error) {
         console.log("Installing chain-spec-builder...");
-        execSync("cargo install staging-chain-spec-builder@16.0.0 --locked", {
+        execSync(`cargo install staging-chain-spec-builder@${process.env.CHAIN_SPEC_BUILDER_VERSION} --locked`, {
           stdio: "inherit",
         });
       }
@@ -73,7 +73,7 @@ describe("Add Existing Pallets Guide", () => {
         console.log(`polkadot-omni-node: ${result.trim()}`);
       } catch (error) {
         console.log("Installing polkadot-omni-node...");
-        execSync("cargo install polkadot-omni-node@0.13.0 --locked", {
+        execSync(`cargo install polkadot-omni-node@${process.env.POLKADOT_OMNI_NODE_VERSION} --locked`, {
           stdio: "inherit",
         });
       }

--- a/polkadot-docs/parachains/customize-runtime/add-existing-pallets/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/add-existing-pallets/vitest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      POLKADOT_OMNI_NODE_VERSION: vars.POLKADOT_OMNI_NODE_VERSION,
+      CHAIN_SPEC_BUILDER_VERSION: vars.CHAIN_SPEC_BUILDER_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/add-pallet-instances/tests/guide.test.ts
@@ -12,7 +12,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const TEMPLATE_DIR = join(WORKSPACE_DIR, "parachain-template");
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const CHAIN_SPEC_PATH = join(WORKSPACE_DIR, "chain_spec.json");
 const PID_FILE = join(WORKSPACE_DIR, "node.pid");
 const WASM_PATH = join(
@@ -59,7 +59,7 @@ describe("Add Pallet Instances Guide", () => {
         console.log(`chain-spec-builder: ${result.trim()}`);
       } catch (error) {
         console.log("Installing chain-spec-builder...");
-        execSync("cargo install staging-chain-spec-builder@16.0.0 --locked", {
+        execSync(`cargo install staging-chain-spec-builder@${process.env.CHAIN_SPEC_BUILDER_VERSION} --locked`, {
           stdio: "inherit",
         });
       }
@@ -74,7 +74,7 @@ describe("Add Pallet Instances Guide", () => {
         console.log(`polkadot-omni-node: ${result.trim()}`);
       } catch (error) {
         console.log("Installing polkadot-omni-node...");
-        execSync("cargo install polkadot-omni-node@0.13.0 --locked", {
+        execSync(`cargo install polkadot-omni-node@${process.env.POLKADOT_OMNI_NODE_VERSION} --locked`, {
           stdio: "inherit",
         });
       }

--- a/polkadot-docs/parachains/customize-runtime/add-pallet-instances/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/add-pallet-instances/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+      POLKADOT_OMNI_NODE_VERSION: vars.POLKADOT_OMNI_NODE_VERSION,
+      CHAIN_SPEC_BUILDER_VERSION: vars.CHAIN_SPEC_BUILDER_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/tests/guide.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const TEMPLATE_DIR = join(WORKSPACE_DIR, "parachain-template");
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const PALLET_DIR = join(TEMPLATE_DIR, "pallets/pallet-custom");
 
 // Pallet Cargo.toml with runtime-benchmarks feature

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/tests/guide.test.ts
@@ -12,7 +12,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const TEMPLATE_DIR = join(WORKSPACE_DIR, "parachain-template");
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const CHAIN_SPEC_PATH = join(WORKSPACE_DIR, "chain_spec.json");
 const PID_FILE = join(WORKSPACE_DIR, "node.pid");
 const WASM_PATH = join(
@@ -210,7 +210,7 @@ describe("Create a Custom Pallet Guide", () => {
         console.log(`chain-spec-builder: ${result.trim()}`);
       } catch (error) {
         console.log("Installing chain-spec-builder...");
-        execSync("cargo install staging-chain-spec-builder@16.0.0 --locked", {
+        execSync(`cargo install staging-chain-spec-builder@${process.env.CHAIN_SPEC_BUILDER_VERSION} --locked`, {
           stdio: "inherit",
         });
       }
@@ -225,7 +225,7 @@ describe("Create a Custom Pallet Guide", () => {
         console.log(`polkadot-omni-node: ${result.trim()}`);
       } catch (error) {
         console.log("Installing polkadot-omni-node...");
-        execSync("cargo install polkadot-omni-node@0.13.0 --locked", {
+        execSync(`cargo install polkadot-omni-node@${process.env.POLKADOT_OMNI_NODE_VERSION} --locked`, {
           stdio: "inherit",
         });
       }

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+      POLKADOT_OMNI_NODE_VERSION: vars.POLKADOT_OMNI_NODE_VERSION,
+      CHAIN_SPEC_BUILDER_VERSION: vars.CHAIN_SPEC_BUILDER_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/tests/guide.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const TEMPLATE_DIR = join(WORKSPACE_DIR, "parachain-template");
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const PALLET_DIR = join(TEMPLATE_DIR, "pallets/pallet-custom");
 
 // Complete pallet implementation from the create-a-pallet guide

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/guide.test.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/tests/guide.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const TEMPLATE_DIR = join(WORKSPACE_DIR, "parachain-template");
-const TEMPLATE_VERSION = "v0.0.5";
+const TEMPLATE_VERSION = process.env.TEMPLATE_VERSION!;
 const PALLET_DIR = join(TEMPLATE_DIR, "pallets/pallet-custom");
 
 // Complete pallet implementation from the create-a-pallet guide

--- a/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/vitest.config.ts
+++ b/polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
+    },
     // Run tests sequentially
     fileParallelism: false,
     sequence: {

--- a/polkadot-docs/parachains/set-up-parachain-template/tests/guide.test.ts
+++ b/polkadot-docs/parachains/set-up-parachain-template/tests/guide.test.ts
@@ -51,7 +51,7 @@ describe("Parachain Template Guide", () => {
         console.log(`chain-spec-builder: ${result.trim()}`);
       } catch (error) {
         console.log("Installing chain-spec-builder...");
-        execSync("cargo install staging-chain-spec-builder@16.0.0 --locked", {
+        execSync(`cargo install staging-chain-spec-builder@${process.env.CHAIN_SPEC_BUILDER_VERSION} --locked`, {
           stdio: "inherit",
         });
       }
@@ -66,7 +66,7 @@ describe("Parachain Template Guide", () => {
         console.log(`polkadot-omni-node: ${result.trim()}`);
       } catch (error) {
         console.log("Installing polkadot-omni-node...");
-        execSync("cargo install polkadot-omni-node@0.13.0 --locked", {
+        execSync(`cargo install polkadot-omni-node@${process.env.POLKADOT_OMNI_NODE_VERSION} --locked`, {
           stdio: "inherit",
         });
       }

--- a/polkadot-docs/parachains/set-up-parachain-template/vitest.config.ts
+++ b/polkadot-docs/parachains/set-up-parachain-template/vitest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vitest/config";
+import { loadVariables } from "../../shared/load-variables";
+
+const vars = loadVariables();
 
 export default defineConfig({
   test: {
+    env: {
+      POLKADOT_OMNI_NODE_VERSION: vars.POLKADOT_OMNI_NODE_VERSION,
+      CHAIN_SPEC_BUILDER_VERSION: vars.CHAIN_SPEC_BUILDER_VERSION,
+    },
     // Run test FILES sequentially (critical - runtime depends on build)
     fileParallelism: false,
     // Run tests within files sequentially

--- a/polkadot-docs/shared/load-variables.ts
+++ b/polkadot-docs/shared/load-variables.ts
@@ -1,0 +1,100 @@
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export interface Variables {
+  TEMPLATE_VERSION: string;
+  POLKADOT_SDK_VERSION: string;
+  ZOMBIENET_VERSION: string;
+  POLKADOT_OMNI_NODE_VERSION: string;
+  CHAIN_SPEC_BUILDER_VERSION: string;
+}
+
+interface YamlNode {
+  [key: string]: string | YamlNode;
+}
+
+function parseSimpleYaml(content: string): YamlNode {
+  const root: YamlNode = {};
+  const stack: { indent: number; obj: YamlNode }[] = [{ indent: -1, obj: root }];
+
+  for (const rawLine of content.split("\n")) {
+    // Skip comments and blank lines
+    if (/^\s*(#|$)/.test(rawLine)) continue;
+
+    const match = rawLine.match(/^(\s*)([\w]+):\s*(.*)/);
+    if (!match) continue;
+
+    const indent = match[1].length;
+    const key = match[2];
+    let value = match[3].trim();
+
+    // Pop stack to find parent at lower indent
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1].obj;
+
+    if (value === "" || value.startsWith("#")) {
+      // This key is a parent node
+      const child: YamlNode = {};
+      parent[key] = child;
+      stack.push({ indent, obj: child });
+    } else {
+      // Strip surrounding quotes
+      value = value.replace(/^["']|["']$/g, "");
+      // Strip inline comments
+      value = value.replace(/\s+#.*$/, "");
+      parent[key] = value;
+    }
+  }
+
+  return root;
+}
+
+function getNestedValue(obj: YamlNode, path: string): string | undefined {
+  const keys = path.split(".");
+  let current: string | YamlNode = obj;
+  for (const key of keys) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = current[key];
+    if (current === undefined) return undefined;
+  }
+  return typeof current === "string" ? current : undefined;
+}
+
+export function loadVariables(): Variables {
+  const repoRoot = execSync("git rev-parse --show-toplevel", {
+    encoding: "utf-8",
+  }).trim();
+
+  const content = readFileSync(join(repoRoot, "versions.yml"), "utf-8");
+  const yaml = parseSimpleYaml(content);
+
+  // Resolve SDK version: template override takes precedence over root default
+  const sdkVersion =
+    getNestedValue(yaml, "parachain_template.polkadot_sdk.release_tag") ??
+    getNestedValue(yaml, "polkadot_sdk.release_tag");
+
+  if (!sdkVersion) throw new Error("Missing polkadot_sdk.release_tag in versions.yml");
+
+  const templateVersion = getNestedValue(yaml, "parachain_template.version");
+  if (!templateVersion) throw new Error("Missing parachain_template.version in versions.yml");
+
+  const zombienetVersion = getNestedValue(yaml, "zombienet.version");
+  if (!zombienetVersion) throw new Error("Missing zombienet.version in versions.yml");
+
+  const omniNodeVersion = getNestedValue(yaml, "parachain_template.crates.polkadot_omni_node.version");
+  if (!omniNodeVersion) throw new Error("Missing parachain_template.crates.polkadot_omni_node.version in versions.yml");
+
+  const chainSpecVersion = getNestedValue(yaml, "parachain_template.crates.chain_spec_builder.version");
+  if (!chainSpecVersion) throw new Error("Missing parachain_template.crates.chain_spec_builder.version in versions.yml");
+
+  return {
+    TEMPLATE_VERSION: templateVersion,
+    POLKADOT_SDK_VERSION: sdkVersion,
+    ZOMBIENET_VERSION: zombienetVersion,
+    POLKADOT_OMNI_NODE_VERSION: omniNodeVersion,
+    CHAIN_SPEC_BUILDER_VERSION: chainSpecVersion,
+  };
+}

--- a/versions.yml
+++ b/versions.yml
@@ -1,0 +1,30 @@
+# Polkadot Cookbook - Dependency Versions
+#
+# Source of truth for all dependency versions used in CI workflows and test harnesses.
+# Upstream reference: https://github.com/polkadot-developers/polkadot-docs/blob/master/variables.yml
+#
+# To update: modify this file and open a PR — all affected workflows run automatically.
+# The sync-versions workflow checks upstream weekly and opens PRs for version bumps.
+
+# Root-level defaults — used unless overridden by a specific dependency below
+polkadot_sdk:
+  release_tag: polkadot-stable2512-1
+  repository: https://github.com/paritytech/polkadot-sdk
+
+parachain_template:
+  version: v0.0.5
+  repository: https://github.com/paritytech/polkadot-sdk-parachain-template
+  # Uncomment to override the root polkadot_sdk version for this template:
+  # polkadot_sdk:
+  #   release_tag: polkadot-stable2503-3
+  crates:
+    polkadot_omni_node:
+      name: polkadot-omni-node
+      version: "0.13.0"
+    chain_spec_builder:
+      name: staging-chain-spec-builder
+      version: "16.0.0"
+
+zombienet:
+  version: v1.3.138
+  repository: https://github.com/paritytech/zombienet


### PR DESCRIPTION
## Summary

- Add `versions.yml` as the single source of truth for all dependency versions (polkadot SDK, parachain template, zombienet, crate versions)
- Add `polkadot-docs/shared/load-variables.ts` — zero-dependency YAML parser that vitest configs use to inject version env vars into tests
- Update all 8 CI workflows to read versions via `yq` from `versions.yml` (cache keys, download URLs, release tags)
- Update all 8 test files to read versions from `process.env` instead of hardcoded strings
- Add `versions.yml` to path triggers so version changes automatically trigger all test workflows
- Add `sync-versions.yml` workflow + script for automated weekly sync against upstream [polkadot-docs variables.yml](https://github.com/polkadot-developers/polkadot-docs/blob/master/variables.yml) — only bumps when upstream is strictly newer, never downgrades

## Test plan

- [ ] All `polkadot-docs-*` workflows trigger on this PR (via `versions.yml` path trigger)
- [ ] "Load versions" step outputs correct values in workflow logs
- [ ] Cache keys use dynamic version strings
- [ ] Tests pass end-to-end (env vars flow from `versions.yml` → `load-variables.ts` → `vitest.config.ts` → `process.env`)
- [ ] Test sync workflow via `workflow_dispatch` — should detect no updates (cookbook is current/ahead of upstream)