### PR TITLE
ci: auto-update last_tested in README frontmatter

### DIFF
--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -95,13 +95,14 @@ jobs:
           npm test
         timeout-minutes: 60
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/add-existing-pallets/README.md'
       workflow_name: 'Add Existing Pallets'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/add-existing-pallets'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -96,13 +96,14 @@ jobs:
           npm test
         timeout-minutes: 60
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/add-pallet-instances/README.md'
       workflow_name: 'Add Pallet Instances'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/add-pallet-instances'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -76,13 +76,14 @@ jobs:
           npm test
         timeout-minutes: 45
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet/README.md'
       workflow_name: 'Benchmark Pallet'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/benchmark-pallet'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -96,13 +96,14 @@ jobs:
           npm test
         timeout-minutes: 60
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet/README.md'
       workflow_name: 'Create a Pallet'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/create-a-pallet'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-fork-a-parachain.yml
+++ b/.github/workflows/polkadot-docs-fork-a-parachain.yml
@@ -30,13 +30,14 @@ jobs:
           npm test
         timeout-minutes: 15
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/testing/fork-a-parachain/README.md'
       workflow_name: 'Fork a Parachain'
-      guide_path: 'polkadot-docs/parachains/testing/fork-a-parachain'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -57,13 +57,14 @@ jobs:
           npm test
         timeout-minutes: 15
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/install-polkadot-sdk/README.md'
       workflow_name: 'Install Polkadot SDK'
-      guide_path: 'polkadot-docs/parachains/install-polkadot-sdk'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -76,13 +76,14 @@ jobs:
           npm test
         timeout-minutes: 45
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime/README.md'
       workflow_name: 'Mock Your Runtime'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/mock-runtime'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -76,13 +76,14 @@ jobs:
           npm test
         timeout-minutes: 45
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing/README.md'
       workflow_name: 'Unit Test Pallets'
-      guide_path: 'polkadot-docs/parachains/customize-runtime/pallet-development/pallet-testing'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -91,13 +91,14 @@ jobs:
           npm test
         timeout-minutes: 60
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/networks/run-a-parachain-network/README.md'
       workflow_name: 'Run a Parachain Network'
-      guide_path: 'polkadot-docs/networks/run-a-parachain-network'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -96,13 +96,14 @@ jobs:
           npm test
         timeout-minutes: 60
 
-  notify-failure:
+  post-test:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
-    uses: ./.github/workflows/notify-docs-failure.yml
+    if: always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
     with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/parachains/set-up-parachain-template/README.md'
       workflow_name: 'Set Up Parachain Template'
-      guide_path: 'polkadot-docs/parachains/set-up-parachain-template'
     permissions:
+      contents: write
       issues: write
-      contents: read

--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -1,19 +1,66 @@
-name: Notify Docs Failure
+name: Post-Test Cleanup
 
 on:
   workflow_call:
     inputs:
+      test_result:
+        required: true
+        type: string
+        description: 'Result of the test job (success/failure)'
+      readme_path:
+        required: true
+        type: string
+        description: 'Path to the README.md file to update'
       workflow_name:
-        required: true
+        required: false
         type: string
-        description: 'Human-readable name of the workflow that failed'
-      guide_path:
-        required: true
-        type: string
-        description: 'Path to the guide directory'
+        default: ''
+        description: 'Human-readable workflow name (for failure notification)'
 
 jobs:
-  notify:
+  update-last-tested:
+    if: inputs.test_result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Update last_tested date
+        id: update
+        run: |
+          TODAY=$(date -u +"%Y-%m-%d")
+          FILE="${{ inputs.readme_path }}"
+          CURRENT=$(sed -n 's/^last_tested: "\(.*\)"/\1/p' "$FILE")
+          if [ "$CURRENT" = "$TODAY" ]; then
+            echo "already_current=true" >> $GITHUB_OUTPUT
+            echo "Date already current ($TODAY), skipping commit"
+          else
+            sed -i "s/^last_tested: \".*\"/last_tested: \"$TODAY\"/" "$FILE"
+            echo "already_current=false" >> $GITHUB_OUTPUT
+            echo "Updated last_tested to $TODAY"
+          fi
+
+      - name: Commit and push
+        if: steps.update.outputs.already_current != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          NAME=$(echo "${{ inputs.readme_path }}" | sed 's|/README.md||' | sed 's|.*/||')
+          git add "${{ inputs.readme_path }}"
+          git commit -m "ci: update last_tested for $NAME [skip ci]"
+          for i in 1 2 3; do
+            git push && break
+            echo "Push failed (attempt $i), rebasing and retrying..."
+            git pull --rebase
+            sleep 2
+          done
+
+  notify-failure:
+    if: inputs.test_result == 'failure' && inputs.workflow_name != ''
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -27,6 +74,12 @@ jobs:
         run: |
           MAINTAINERS=$(cat polkadot-docs/MAINTAINERS | tr '\n' ' ')
           echo "list=$MAINTAINERS" >> $GITHUB_OUTPUT
+
+      - name: Derive guide path
+        id: guide
+        run: |
+          GUIDE_PATH=$(echo "${{ inputs.readme_path }}" | sed 's|/README.md||')
+          echo "path=$GUIDE_PATH" >> $GITHUB_OUTPUT
 
       - name: Check for existing issue
         id: check_issue
@@ -49,7 +102,7 @@ jobs:
           BODY="The **${{ inputs.workflow_name }}** guide test is failing on master.
 
           **Details:**
-          - Guide: \`${{ inputs.guide_path }}\`
+          - Guide: \`${{ steps.guide.outputs.path }}\`
           - Commit: \`${{ github.sha }}\`
           - Failed run: [View logs]($RUN_URL)
 

--- a/.github/workflows/recipe-contracts-example.yml
+++ b/.github/workflows/recipe-contracts-example.yml
@@ -29,3 +29,13 @@ jobs:
           cd recipes/contracts/contracts-example
           npm test
         timeout-minutes: 15
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/contracts/contracts-example/README.md'
+    permissions:
+      contents: write

--- a/.github/workflows/recipe-network-example.yml
+++ b/.github/workflows/recipe-network-example.yml
@@ -29,3 +29,13 @@ jobs:
           cd recipes/networks/network-example
           npm test
         timeout-minutes: 15
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/networks/network-example/README.md'
+    permissions:
+      contents: write

--- a/.github/workflows/recipe-pallet-example.yml
+++ b/.github/workflows/recipe-pallet-example.yml
@@ -42,3 +42,13 @@ jobs:
           cd recipes/pallets/pallet-example
           npm test
         timeout-minutes: 60
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/pallets/pallet-example/README.md'
+    permissions:
+      contents: write

--- a/.github/workflows/recipe-parachain-example.yml
+++ b/.github/workflows/recipe-parachain-example.yml
@@ -59,3 +59,13 @@ jobs:
           cd recipes/parachains/parachain-example
           npm test
         timeout-minutes: 60
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/parachains/parachain-example/README.md'
+    permissions:
+      contents: write

--- a/.github/workflows/recipe-transaction-example.yml
+++ b/.github/workflows/recipe-transaction-example.yml
@@ -29,3 +29,13 @@ jobs:
           cd recipes/transactions/transaction-example
           npm test
         timeout-minutes: 15
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/transactions/transaction-example/README.md'
+    permissions:
+      contents: write

--- a/.github/workflows/recipe-xcm-example.yml
+++ b/.github/workflows/recipe-xcm-example.yml
@@ -29,3 +29,13 @@ jobs:
           cd recipes/cross-chain-transactions/cross-chain-transaction-example
           npm test
         timeout-minutes: 15
+
+  post-test:
+    needs: test
+    if: success() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'recipes/cross-chain-transactions/cross-chain-transaction-example/README.md'
+    permissions:
+      contents: write

--- a/recipes/contracts/contracts-example/README.md
+++ b/recipes/contracts/contracts-example/README.md
@@ -2,6 +2,7 @@
 title: "Contracts Example"
 description: "Verification tests for the contracts-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-contracts-example"
+last_tested: "2025-02-13"
 ---
 
 # Contracts Example

--- a/recipes/cross-chain-transactions/cross-chain-transaction-example/README.md
+++ b/recipes/cross-chain-transactions/cross-chain-transaction-example/README.md
@@ -2,6 +2,7 @@
 title: "Cross-Chain Transaction Example"
 description: "Verification tests for the cross-chain-transaction-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-xcm-example"
+last_tested: "2025-02-13"
 ---
 
 # Cross-Chain Transaction Example

--- a/recipes/networks/network-example/README.md
+++ b/recipes/networks/network-example/README.md
@@ -2,6 +2,7 @@
 title: "Network Example"
 description: "Verification tests for the network-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-network-example"
+last_tested: "2025-02-13"
 ---
 
 # Network Example

--- a/recipes/pallets/pallet-example/README.md
+++ b/recipes/pallets/pallet-example/README.md
@@ -2,6 +2,7 @@
 title: "Pallet Example"
 description: "Verification tests for the pallet-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-pallet-example"
+last_tested: "2025-02-13"
 ---
 
 # Pallet Example

--- a/recipes/parachains/parachain-example/README.md
+++ b/recipes/parachains/parachain-example/README.md
@@ -2,6 +2,7 @@
 title: "Parachain Example"
 description: "Verification tests for the parachain-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-parachain-example"
+last_tested: "2025-02-13"
 ---
 
 # Parachain Example

--- a/recipes/transactions/transaction-example/README.md
+++ b/recipes/transactions/transaction-example/README.md
@@ -2,6 +2,7 @@
 title: "Transaction Example"
 description: "Verification tests for the transaction-example recipe"
 source_repo: "https://github.com/brunopgalvao/recipe-transaction-example"
+last_tested: "2025-02-13"
 ---
 
 # Transaction Example


### PR DESCRIPTION
## Summary

- Replace `notify-docs-failure.yml` with `post-cleanup.yml` reusable workflow that handles both test outcomes:
  - **On success:** updates `last_tested` date in the README frontmatter and pushes with `[skip ci]`
  - **On failure:** creates/updates a GitHub issue (existing behavior, polkadot-docs only)
- All 10 polkadot-docs workflows and 6 recipe workflows now call `post-cleanup.yml` via a unified `post-test` job
- Add `last_tested` frontmatter field to 6 recipe READMEs

## Test plan

- [ ] Verify `post-test` job is **skipped** on this PR (since `github.ref` is not master)
- [ ] After merge to master, verify `update-last-tested` job runs and commits with `[skip ci]`
- [ ] Verify no cascading workflow runs are triggered by the automated commit
- [ ] Check that the README `last_tested` date is updated to today's date
- [ ] Test a failure scenario to verify existing issue-notification behavior still works