### PR TITLE
fix(ci): add issues:write permission to recipe post-test jobs

### DIFF
--- a/.github/workflows/recipe-contracts-example.yml
+++ b/.github/workflows/recipe-contracts-example.yml
@@ -39,3 +39,4 @@ jobs:
       readme_path: 'recipes/contracts/contracts-example/README.md'
     permissions:
       contents: write
+      issues: write

--- a/.github/workflows/recipe-network-example.yml
+++ b/.github/workflows/recipe-network-example.yml
@@ -39,3 +39,4 @@ jobs:
       readme_path: 'recipes/networks/network-example/README.md'
     permissions:
       contents: write
+      issues: write

--- a/.github/workflows/recipe-pallet-example.yml
+++ b/.github/workflows/recipe-pallet-example.yml
@@ -52,3 +52,4 @@ jobs:
       readme_path: 'recipes/pallets/pallet-example/README.md'
     permissions:
       contents: write
+      issues: write

--- a/.github/workflows/recipe-parachain-example.yml
+++ b/.github/workflows/recipe-parachain-example.yml
@@ -69,3 +69,4 @@ jobs:
       readme_path: 'recipes/parachains/parachain-example/README.md'
     permissions:
       contents: write
+      issues: write

--- a/.github/workflows/recipe-transaction-example.yml
+++ b/.github/workflows/recipe-transaction-example.yml
@@ -39,3 +39,4 @@ jobs:
       readme_path: 'recipes/transactions/transaction-example/README.md'
     permissions:
       contents: write
+      issues: write

--- a/.github/workflows/recipe-xcm-example.yml
+++ b/.github/workflows/recipe-xcm-example.yml
@@ -39,3 +39,4 @@ jobs:
       readme_path: 'recipes/cross-chain-transactions/cross-chain-transaction-example/README.md'
     permissions:
       contents: write
+      issues: write


### PR DESCRIPTION
## Summary

- Add `issues: write` permission to the `post-test` job in all 6 recipe workflows

The reusable `post-cleanup.yml` workflow declares `issues: write` internally on its `notify-failure` job. Even though recipes never trigger that job (no `workflow_name` is passed), GitHub validates all permissions in the reusable workflow at startup and fails with `startup_failure` if the caller doesn't grant them.

## Test plan

- [ ] Verify recipe workflows no longer fail with `startup_failure`
- [ ] Verify `update-last-tested` job runs and commits successfully