### PR TITLE
fix(ci): create PR instead of pushing directly to master

### DIFF
--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -106,3 +106,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -107,3 +107,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -87,3 +87,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -107,3 +107,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-fork-a-parachain.yml
+++ b/.github/workflows/polkadot-docs-fork-a-parachain.yml
@@ -41,3 +41,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -68,3 +68,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -87,3 +87,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -87,3 +87,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -102,3 +102,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -107,3 +107,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -44,20 +45,27 @@ jobs:
             echo "Updated last_tested to $TODAY"
           fi
 
-      - name: Commit and push
+      - name: Create PR
         if: steps.update.outputs.already_current != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           NAME=$(echo "${{ inputs.readme_path }}" | sed 's|/README.md||' | sed 's|.*/||')
+          BRANCH="ci/update-last-tested-${NAME}"
+          git checkout -b "$BRANCH"
           git add "${{ inputs.readme_path }}"
-          git commit -m "ci: update last_tested for $NAME [skip ci]"
-          for i in 1 2 3; do
-            git push && break
-            echo "Push failed (attempt $i), rebasing and retrying..."
-            git pull --rebase
-            sleep 2
-          done
+          git commit -m "ci: update last_tested for $NAME"
+          git push -u origin "$BRANCH" --force
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --title "ci: update last_tested for $NAME" \
+              --body "Auto-generated PR to update \`last_tested\` date in \`${{ inputs.readme_path }}\`." \
+              --label "automated"
+            gh pr merge "$BRANCH" --auto --squash
+          fi
 
   notify-failure:
     if: inputs.test_result == 'failure' && inputs.workflow_name != ''

--- a/.github/workflows/recipe-contracts-example.yml
+++ b/.github/workflows/recipe-contracts-example.yml
@@ -40,3 +40,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/recipe-network-example.yml
+++ b/.github/workflows/recipe-network-example.yml
@@ -40,3 +40,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/recipe-pallet-example.yml
+++ b/.github/workflows/recipe-pallet-example.yml
@@ -53,3 +53,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/recipe-parachain-example.yml
+++ b/.github/workflows/recipe-parachain-example.yml
@@ -70,3 +70,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/recipe-transaction-example.yml
+++ b/.github/workflows/recipe-transaction-example.yml
@@ -40,3 +40,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write

--- a/.github/workflows/recipe-xcm-example.yml
+++ b/.github/workflows/recipe-xcm-example.yml
@@ -40,3 +40,4 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Change `update-last-tested` job in `post-cleanup.yml` to create a branch, open a PR, and enable auto-merge instead of pushing directly to master (which is blocked by branch protection)
- Add `pull-requests: write` permission to all 16 calling workflows

## Test plan

- [ ] Trigger a workflow via `workflow_dispatch` and verify it creates a PR with auto-merge enabled
- [ ] Verify the PR gets auto-merged once status checks pass