### PR TITLE
fix(ci): remove non-existent label from PR creation

### DIFF
--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -62,8 +62,7 @@ jobs:
           if [ -z "$EXISTING_PR" ]; then
             gh pr create \
               --title "ci: update last_tested for $NAME" \
-              --body "Auto-generated PR to update \`last_tested\` date in \`${{ inputs.readme_path }}\`." \
-              --label "automated"
+              --body "Auto-generated PR to update \`last_tested\` date in \`${{ inputs.readme_path }}\`."
             gh pr merge "$BRANCH" --auto --squash
           fi
 


### PR DESCRIPTION
The `automated` label doesn't exist in the repo, causing `gh pr create` to fail.