### PR TITLE
ci: add fork protection guards to all workflows

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   analyze-commits:
-    if: github.event_name == 'pull_request'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   generate-description:
-    if: github.event_name == 'pull_request'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/migration-revm-uniswap-v2-core.yml
+++ b/.github/workflows/migration-revm-uniswap-v2-core.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   notify-failure:
     needs: test
-    if: failure() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && failure() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/notify-docs-failure.yml
     with:
       workflow_name: 'REVM Uniswap V2 Core'

--- a/.github/workflows/migration-scheduled.yml
+++ b/.github/workflows/migration-scheduled.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger-all:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -97,7 +98,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -98,7 +99,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,7 +79,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -98,7 +99,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-fork-a-parachain.yml
+++ b/.github/workflows/polkadot-docs-fork-a-parachain.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -59,7 +60,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,7 +79,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,7 +79,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -93,7 +94,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-scheduled.yml
+++ b/.github/workflows/polkadot-docs-scheduled.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger-all:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -98,7 +99,7 @@ jobs:
 
   post-test:
     needs: test
-    if: always() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   update-last-tested:
-    if: inputs.test_result == 'success'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && inputs.test_result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,7 +67,7 @@ jobs:
           fi
 
   notify-failure:
-    if: inputs.test_result == 'failure' && inputs.workflow_name != ''
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && inputs.test_result == 'failure' && inputs.workflow_name != ''
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   detect-version:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -47,7 +48,7 @@ jobs:
 
   build-cli-binaries:
     needs: detect-version
-    if: needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
     name: Build CLI Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
 
@@ -149,7 +150,7 @@ jobs:
 
   publish-release:
     needs: [detect-version, build-cli-binaries]
-    if: needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.detect-version.outputs.skip == 'false' && needs.detect-version.outputs.version != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/recipe-contracts-example.yml
+++ b/.github/workflows/recipe-contracts-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-network-example.yml
+++ b/.github/workflows/recipe-network-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-pallet-example.yml
+++ b/.github/workflows/recipe-pallet-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,7 +46,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-parachain-example.yml
+++ b/.github/workflows/recipe-parachain-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -62,7 +63,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-transaction-example.yml
+++ b/.github/workflows/recipe-transaction-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-xcm-example.yml
+++ b/.github/workflows/recipe-xcm-example.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +33,7 @@ jobs:
 
   post-test:
     needs: test
-    if: success() && github.ref == 'refs/heads/master'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   build-binaries:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: Build CLI Binary (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     permissions:
@@ -129,6 +130,7 @@ jobs:
           if-no-files-found: error
 
   create-release:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: Create GitHub Release
     needs: build-binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/release-on-breaking-change.yml
+++ b/.github/workflows/release-on-breaking-change.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   detect-breaking-change:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     outputs:
       has_breaking: ${{ steps.check.outputs.has_breaking }}
@@ -109,7 +110,7 @@ jobs:
 
   get-cli-version:
     needs: detect-breaking-change
-    if: needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'CLI'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'CLI'
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version.outputs.new }}
@@ -133,7 +134,7 @@ jobs:
 
   release-cli:
     needs: [detect-breaking-change, get-cli-version]
-    if: needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'CLI'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'CLI'
     uses: ./.github/workflows/release-cli.yml
     permissions:
       contents: write
@@ -144,7 +145,7 @@ jobs:
 
   release-sdk:
     needs: detect-breaking-change
-    if: needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'SDK'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.detect-breaking-change.outputs.has_breaking == 'true' && needs.detect-breaking-change.outputs.component == 'SDK'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -242,6 +243,7 @@ jobs:
   test-and-release-recipes:
     needs: [detect-breaking-change, release-cli, release-sdk]
     if: |
+      github.repository == 'polkadot-developers/polkadot-cookbook' &&
       always() &&
       needs.detect-breaking-change.outputs.has_breaking == 'true' &&
       (needs.release-cli.result == 'success' || needs.release-sdk.result == 'success')

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   check-changes:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
@@ -132,7 +133,7 @@ jobs:
 
   test-recipes:
     needs: check-changes
-    if: needs.check-changes.outputs.has_changes == 'true'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -220,7 +221,7 @@ jobs:
 
   create-release:
     needs: [check-changes, test-recipes]
-    if: needs.check-changes.outputs.has_changes == 'true'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   sync:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test-pathway-integration.yml
+++ b/.github/workflows/test-pathway-integration.yml
@@ -31,6 +31,7 @@ on:
 
 jobs:
   test-pathways:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: Test All Recipe Pathways
     runs-on: ubuntu-latest
     timeout-minutes: 90  # Integration tests can take a while with cold cache
@@ -203,8 +204,8 @@ jobs:
   test-summary:
     name: Integration Test Summary
     needs: test-pathways
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always()
     runs-on: ubuntu-latest
-    if: always()
 
     steps:
       - name: Check test results

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   check-changes:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: Detect SDK Changes
     runs-on: ubuntu-latest
     outputs:
@@ -46,6 +47,7 @@ jobs:
           fi
 
   test-sdk:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: SDK Library
     needs: check-changes
     runs-on: ubuntu-latest
@@ -266,6 +268,7 @@ jobs:
           echo "✅ SDK library coverage ${SDK_COVERAGE}% meets threshold of 80%"
 
   test-cli:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: CLI
     runs-on: ubuntu-latest
     needs: [check-changes, test-sdk]
@@ -339,6 +342,7 @@ jobs:
         run: cargo run --package cli --locked -- --help
 
   build-workspace:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
     name: Build Workspace
     needs: check-changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `if: github.repository == 'polkadot-developers/polkadot-cookbook'` to all 60 jobs across 29 workflow files
- Prevents workflows from running on forked repositories, particularly scheduled workflows that automatically trigger on forks
- Jobs with existing `if` conditions have the repo check prepended with `&&`

## Test plan
- [ ] Verify workflows still trigger correctly on the main repo
- [ ] Fork the repo and confirm workflows are skipped