### PR TITLE
ci: add stale issue and PR automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Stale Issues & PRs
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # Daily at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 7
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with
+            no activity.
+          close-pr-message: >
+            This PR was closed because it has been stale for 14 days with
+            no activity.
+          exempt-issue-labels: override-stale
+          exempt-pr-labels: override-stale


### PR DESCRIPTION
## Summary
- Add daily stale check workflow using `actions/stale@v9`
- Issues/PRs marked stale after 7 days of inactivity
- Stale issues/PRs closed after another 7 days (14 total)
- `override-stale` label exempts specific issues/PRs

## Test plan
- [ ] Trigger manually via `workflow_dispatch` to verify it runs
- [ ] Verify `override-stale` label prevents marking/closing