### PR TITLE
chore: add CODEOWNERS for automatic PR review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default owner for everything
+* @brunopgalvao
+
+# Smart contracts
+/recipes/contracts/ @nhussein11
+/migration/ @nhussein11
+/dot/sdk/templates/project-templates/solidity-template/ @nhussein11


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` to automatically assign PR reviewers
- `@nhussein11` is assigned to smart contract paths: `recipes/contracts/`, `migration/`, and the solidity template
- `@brunopgalvao` is the default owner for everything else

## Test plan
- [ ] Open a PR touching `recipes/contracts/` and verify `@nhussein11` is requested for review
- [ ] Open a PR touching other paths and verify `@brunopgalvao` is requested