### PR TITLE
Fix fork-a-parachain test timeouts in CI

### DIFF
--- a/polkadot-docs/parachains/testing/fork-a-parachain/configs/chopsticks.yml
+++ b/polkadot-docs/parachains/testing/fork-a-parachain/configs/chopsticks.yml
@@ -1,5 +1,6 @@
 endpoint:
   - wss://rpc.ibp.network/polkadot
   - wss://polkadot-rpc.dwellir.com
+  - wss://polkadot.public.curie.radiumblock.co/ws
 mock-signature-host: true
 port: 8000


### PR DESCRIPTION
## Summary
- Increase default RPC call timeout from 30s to 60s for Chopsticks state-fetching calls
- Add `rpcCallWithRetry()` helper with 3 attempts and 5s delay between retries
- Add warm-up `chain_getHeader` call after Chopsticks startup to prime the state cache
- Add third fallback RPC endpoint (`radiumblock.co`) for redundancy

## Test plan
- [x] All 10 tests pass locally
- [ ] Trigger `workflow_dispatch` for `polkadot-docs-fork-a-parachain.yml` and verify all tests pass in CI