### PR TITLE
ci: fix branch checkout in batch last_tested workflow

### DIFF
--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -60,6 +60,9 @@ jobs:
           NAME=$(echo "${{ inputs.readme_path }}" | sed 's|/README.md||' | sed 's|.*/||')
           BRANCH="ci/update-last-tested"
 
+          # Stash the updated file so we can switch branches cleanly
+          git stash
+
           # Pick up existing branch or start fresh from master
           if git fetch origin "$BRANCH" 2>/dev/null; then
             git checkout "$BRANCH"
@@ -67,6 +70,9 @@ jobs:
           else
             git checkout -b "$BRANCH"
           fi
+
+          # Re-apply the date update on this branch
+          git stash pop
 
           git add "${{ inputs.readme_path }}"
 


### PR DESCRIPTION
## Summary

- Fix the batch `last_tested` workflow failing when `ci/update-last-tested` branch already exists
- The "Update last_tested date" step modifies the file on master, so `git checkout` to the existing branch fails with dirty working tree
- Stash before checkout and pop after to carry the changes to the target branch

## Context

Follow-up fix to #140. The first test run hit this error:
```
error: Your local changes to the following files would be overwritten by checkout:
    recipes/contracts/contracts-example/README.md
```