### PR TITLE
ci: remove @nhussein11 from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,2 @@
 # Default owner for everything
 * @brunopgalvao
-
-# Smart contracts
-/recipes/contracts/ @nhussein11
-/migration/ @nhussein11
-/dot/sdk/templates/project-templates/solidity-template/ @nhussein11


### PR DESCRIPTION
## Summary

- Remove `@nhussein11` as code owner for `/recipes/contracts/`, `/migration/`, and `/dot/sdk/templates/project-templates/solidity-template/`
- Reduces review request noise for PRs touching those paths