### PR TITLE
feat: custom dark-themed GitHub Pages site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,1583 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Polkadot Cookbook &mdash; Practical recipes for Polkadot development</title>
+  <meta name="description" content="Practical, tested recipes for building on Polkadot. Build runtime logic, smart contracts, dApps, and cross-chain applications with working code examples.">
+  <meta name="theme-color" content="#08080d" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#fafafc" media="(prefers-color-scheme: light)">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta property="og:title" content="Polkadot Cookbook">
+  <meta property="og:description" content="Practical, tested recipes for building on Polkadot">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://polkadot-developers.github.io/polkadot-cookbook/">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='40' fill='%23E6007A'/></svg>">
+  <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'><rect width='180' height='180' rx='40' fill='%2308080d'/><circle cx='90' cy='90' r='50' fill='%23E6007A'/></svg>">
+  <link rel="manifest" href="data:application/manifest+json,%7B%22name%22%3A%22Polkadot%20Cookbook%22%2C%22short_name%22%3A%22Cookbook%22%2C%22start_url%22%3A%22.%22%2C%22display%22%3A%22standalone%22%2C%22background_color%22%3A%22%2308080d%22%2C%22theme_color%22%3A%22%23E6007A%22%2C%22description%22%3A%22Practical%2C%20tested%20recipes%20for%20building%20on%20Polkadot%22%7D">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    /* ── Reset & Variables ──────────────────────────────────── */
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg-deep: #06060b;
+      --bg-primary: #08080d;
+      --bg-secondary: #0f0f17;
+      --bg-card: #111119;
+      --bg-card-hover: #161622;
+      --bg-code: #0a0a12;
+      --border-subtle: rgba(230, 0, 122, 0.07);
+      --border-medium: rgba(230, 0, 122, 0.14);
+      --border-hover: rgba(230, 0, 122, 0.30);
+      --pink: #E6007A;
+      --pink-dim: #c4006a;
+      --pink-glow: rgba(230, 0, 122, 0.35);
+      --pink-soft: rgba(230, 0, 122, 0.08);
+      --deep-blue: #11116B;
+      --text-primary: #dfdfe8;
+      --text-secondary: #78788e;
+      --text-muted: #484860;
+      --font-display: 'Plus Jakarta Sans', sans-serif;
+      --font-body: 'Plus Jakarta Sans', sans-serif;
+      --font-mono: 'JetBrains Mono', monospace;
+      --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+      --safe-top: env(safe-area-inset-top, 0px);
+      --safe-bottom: env(safe-area-inset-bottom, 0px);
+      --safe-left: env(safe-area-inset-left, 0px);
+      --safe-right: env(safe-area-inset-right, 0px);
+    }
+
+    [data-theme="light"] {
+      --bg-deep: #f4f4f8;
+      --bg-primary: #fafafc;
+      --bg-secondary: #ededf2;
+      --bg-card: #ffffff;
+      --bg-card-hover: #f5f5fa;
+      --bg-code: #f0f0f5;
+      --border-subtle: rgba(17, 17, 107, 0.07);
+      --border-medium: rgba(17, 17, 107, 0.12);
+      --border-hover: rgba(230, 0, 122, 0.25);
+      --pink-soft: rgba(230, 0, 122, 0.06);
+      --text-primary: #18182a;
+      --text-secondary: #5a5a72;
+      --text-muted: #8a8aa0;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font-body);
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.65;
+      font-size: 16px;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      overflow-x: hidden;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    a { color: var(--pink); text-decoration: none; transition: opacity 0.2s; }
+    a:hover { opacity: 0.8; }
+
+    /* ── Navigation ─────────────────────────────────────────── */
+    .nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 100;
+      padding: 0 max(1.25rem, var(--safe-left));
+      padding-top: var(--safe-top);
+      height: calc(60px + var(--safe-top));
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      transition: background 0.4s, border-color 0.4s;
+      border-bottom: 1px solid transparent;
+    }
+
+    .nav.scrolled {
+      background: rgba(8, 8, 13, 0.82);
+      backdrop-filter: blur(24px) saturate(1.4);
+      -webkit-backdrop-filter: blur(24px) saturate(1.4);
+      border-bottom-color: var(--border-subtle);
+    }
+
+    [data-theme="light"] .nav.scrolled {
+      background: rgba(250, 250, 252, 0.85);
+    }
+
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1rem;
+      color: var(--text-primary);
+      text-decoration: none;
+      min-height: 44px;
+    }
+
+    .nav-brand:hover { opacity: 1; }
+
+    .nav-dot {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--pink);
+      box-shadow: 0 0 16px var(--pink-glow);
+      flex-shrink: 0;
+    }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      list-style: none;
+    }
+
+    .nav-links a, .nav-links button {
+      min-height: 44px;
+      min-width: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .nav-links a {
+      font-size: 0.88rem;
+      font-weight: 500;
+      color: var(--text-secondary);
+      transition: color 0.2s;
+    }
+
+    .nav-links a:hover { color: var(--text-primary); opacity: 1; }
+
+    .theme-toggle {
+      background: none;
+      border: 1px solid var(--border-medium);
+      color: var(--text-secondary);
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: border-color 0.2s, color 0.2s;
+      font-size: 1.05rem;
+    }
+
+    .theme-toggle:hover {
+      border-color: var(--border-hover);
+      color: var(--text-primary);
+    }
+
+    .gh-link {
+      display: flex;
+      align-items: center;
+    }
+
+    .gh-link svg {
+      width: 22px;
+      height: 22px;
+      fill: var(--text-secondary);
+      transition: fill 0.2s;
+    }
+
+    .gh-link:hover svg { fill: var(--text-primary); }
+
+    .nav-mobile-toggle {
+      display: none;
+      background: none;
+      border: none;
+      color: var(--text-primary);
+      font-size: 1.5rem;
+      cursor: pointer;
+      min-width: 44px;
+      min-height: 44px;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* ── Mobile Nav Overlay ──────────────────────────────────── */
+    .nav-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 99;
+      background: rgba(6, 6, 11, 0.6);
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+      opacity: 0;
+      transition: opacity 0.3s;
+    }
+
+    .nav-overlay.open {
+      display: block;
+      opacity: 1;
+    }
+
+    /* ── Hero ────────────────────────────────────────────────── */
+    .hero {
+      position: relative;
+      min-height: 100svh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: calc(80px + var(--safe-top)) 1.25rem 60px;
+      overflow: hidden;
+    }
+
+    .hero-canvas {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+    }
+
+    .hero-gradient {
+      position: absolute;
+      inset: 0;
+      background:
+        radial-gradient(ellipse 60% 50% at 50% 45%, rgba(230, 0, 122, 0.06) 0%, transparent 70%),
+        radial-gradient(ellipse 80% 60% at 50% 50%, rgba(17, 17, 107, 0.05) 0%, transparent 70%);
+      z-index: 1;
+    }
+
+    [data-theme="light"] .hero-gradient {
+      background:
+        radial-gradient(ellipse 60% 50% at 50% 45%, rgba(230, 0, 122, 0.04) 0%, transparent 70%),
+        radial-gradient(ellipse 80% 60% at 50% 50%, rgba(17, 17, 107, 0.03) 0%, transparent 70%);
+    }
+
+    .hero-content {
+      position: relative;
+      z-index: 2;
+      max-width: 720px;
+      width: 100%;
+    }
+
+    .hero-logo {
+      width: 72px;
+      height: 72px;
+      margin: 0 auto 1.5rem;
+      animation: hero-fade-in 1s var(--ease-out-expo) both;
+    }
+
+    .hero-title {
+      font-family: var(--font-display);
+      font-weight: 800;
+      font-style: normal;
+      font-size: clamp(2.2rem, 8vw, 4.2rem);
+      line-height: 1.08;
+      letter-spacing: -0.025em;
+      margin-bottom: 1rem;
+      animation: hero-fade-in 1s var(--ease-out-expo) 0.1s both;
+    }
+
+    .hero-title .accent {
+      background: linear-gradient(135deg, var(--pink) 0%, #ff3d9a 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .hero-tagline {
+      font-size: clamp(0.95rem, 2.5vw, 1.2rem);
+      color: var(--text-secondary);
+      max-width: 520px;
+      margin: 0 auto 2rem;
+      line-height: 1.6;
+      animation: hero-fade-in 1s var(--ease-out-expo) 0.2s both;
+    }
+
+    .hero-actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-bottom: 2rem;
+      animation: hero-fade-in 1s var(--ease-out-expo) 0.3s both;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 0.8rem 1.75rem;
+      border-radius: 12px;
+      font-family: var(--font-body);
+      font-size: 0.92rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.25s var(--ease-out-expo);
+      border: none;
+      text-decoration: none;
+      min-height: 48px;
+      -webkit-touch-callout: none;
+    }
+
+    .btn-primary {
+      background: var(--pink);
+      color: #fff;
+      box-shadow: 0 4px 24px rgba(230, 0, 122, 0.25);
+    }
+
+    .btn-primary:hover {
+      opacity: 1;
+      transform: translateY(-1px);
+      box-shadow: 0 6px 32px rgba(230, 0, 122, 0.35);
+    }
+
+    .btn-primary:active {
+      transform: translateY(0);
+      box-shadow: 0 2px 16px rgba(230, 0, 122, 0.25);
+    }
+
+    .btn-secondary {
+      background: var(--bg-card);
+      color: var(--text-primary);
+      border: 1px solid var(--border-medium);
+    }
+
+    .btn-secondary:hover {
+      opacity: 1;
+      border-color: var(--border-hover);
+      transform: translateY(-1px);
+    }
+
+    .btn-secondary:active { transform: translateY(0); }
+
+    .hero-badges {
+      display: flex;
+      gap: 6px;
+      justify-content: center;
+      flex-wrap: wrap;
+      animation: hero-fade-in 1s var(--ease-out-expo) 0.4s both;
+    }
+
+    .hero-badges img {
+      height: 22px;
+      border-radius: 4px;
+    }
+
+    @keyframes hero-fade-in {
+      from { opacity: 0; transform: translateY(16px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* ── Section Layout ─────────────────────────────────────── */
+    .section {
+      padding: 4rem 1.25rem;
+      max-width: 1080px;
+      margin: 0 auto;
+    }
+
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 500;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--pink);
+      margin-bottom: 0.6rem;
+    }
+
+    .section-title {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-style: normal;
+      font-size: clamp(1.5rem, 4vw, 2.2rem);
+      margin-bottom: 0.75rem;
+      letter-spacing: -0.015em;
+    }
+
+    .section-desc {
+      color: var(--text-secondary);
+      font-size: clamp(0.92rem, 2vw, 1.05rem);
+      max-width: 560px;
+      margin-bottom: 2.5rem;
+    }
+
+    /* ── Animated Gradient Divider ──────────────────────────── */
+    .gradient-divider {
+      height: 2px;
+      background: linear-gradient(90deg, #E6007A 0%, #11116B 25%, #E6007A 50%, #11116B 75%, #E6007A 100%);
+      background-size: 200% 100%;
+      border: none;
+      max-width: 1080px;
+      margin: 0 auto;
+      opacity: 0.4;
+      animation: gradient-flow 8s ease-in-out infinite;
+    }
+
+    @keyframes gradient-flow {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+
+    /* ── Recipe Cards ───────────────────────────────────────── */
+    .recipe-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .recipe-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 14px;
+      padding: 1.5rem;
+      position: relative;
+      overflow: hidden;
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+
+    .recipe-card::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 3px;
+      height: 100%;
+      background: var(--pink);
+      opacity: 0.25;
+      transition: opacity 0.3s;
+    }
+
+    .recipe-card-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      background: var(--pink-soft);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 0.85rem;
+    }
+
+    .recipe-card-icon svg {
+      width: 20px;
+      height: 20px;
+      stroke: var(--pink);
+      fill: none;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .recipe-card h3 {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-style: normal;
+      font-size: 1.05rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .recipe-card p {
+      font-size: 0.88rem;
+      color: var(--text-secondary);
+      margin-bottom: 1rem;
+      line-height: 1.55;
+    }
+
+    .recipe-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .recipe-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 0.45rem 0.85rem;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-subtle);
+      border-radius: 8px;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--text-secondary);
+      transition: border-color 0.2s, color 0.2s, background 0.2s;
+      min-height: 36px;
+    }
+
+    .recipe-link:hover {
+      border-color: var(--border-hover);
+      color: var(--pink);
+      background: var(--pink-soft);
+      opacity: 1;
+    }
+
+    .recipe-link:active {
+      background: rgba(230, 0, 122, 0.12);
+    }
+
+    .recipe-link svg {
+      width: 12px;
+      height: 12px;
+      stroke: currentColor;
+      fill: none;
+      stroke-width: 2;
+    }
+
+    /* ── Quick Start ─────────────────────────────────────────── */
+    .quickstart-steps {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .step {
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 14px;
+      padding: 1.5rem;
+    }
+
+    .step-number {
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      font-weight: 500;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--pink);
+      margin-bottom: 0.6rem;
+    }
+
+    .step h3 {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-style: normal;
+      font-size: 1.02rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .step p {
+      font-size: 0.88rem;
+      color: var(--text-secondary);
+      margin-bottom: 1rem;
+    }
+
+    .code-block {
+      background: var(--bg-code);
+      border: 1px solid var(--border-subtle);
+      border-left: 3px solid var(--pink);
+      border-radius: 10px;
+      padding: 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-primary);
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      position: relative;
+      line-height: 1.75;
+      white-space: pre;
+      word-break: keep-all;
+    }
+
+    .code-block .prompt { color: var(--pink); user-select: none; }
+    .code-block .comment { color: var(--text-muted); }
+
+    .copy-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-subtle);
+      color: var(--text-muted);
+      width: 36px;
+      height: 36px;
+      border-radius: 8px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.2s;
+      font-size: 0.85rem;
+    }
+
+    .copy-btn:hover {
+      border-color: var(--border-hover);
+      color: var(--text-primary);
+    }
+
+    .copy-btn:active { transform: scale(0.92); }
+    .copy-btn.copied { color: var(--pink); }
+
+    /* ── Docs Grid ───────────────────────────────────────────── */
+    .docs-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .doc-card {
+      display: block;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 14px;
+      padding: 1.25rem;
+      transition: border-color 0.3s;
+      text-decoration: none;
+    }
+
+    .doc-card:active {
+      background: var(--bg-card-hover);
+    }
+
+    .doc-card h3 {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-style: normal;
+      font-size: 0.95rem;
+      margin-bottom: 0.35rem;
+      color: var(--text-primary);
+    }
+
+    .doc-card p {
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+    }
+
+    .doc-card .doc-arrow {
+      display: inline-block;
+      margin-top: 0.6rem;
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: var(--pink);
+    }
+
+    /* ── Contributing CTA ────────────────────────────────────── */
+    .cta-section {
+      padding: 3rem 1.25rem;
+    }
+
+    .cta-box {
+      max-width: 1080px;
+      margin: 0 auto;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 20px;
+      padding: 3rem 1.5rem;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .cta-box::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(ellipse 70% 60% at 50% 0%, rgba(230, 0, 122, 0.05) 0%, transparent 60%);
+      pointer-events: none;
+    }
+
+    .cta-box h2 {
+      font-family: var(--font-display);
+      font-weight: 800;
+      font-style: normal;
+      font-size: clamp(1.35rem, 4vw, 2rem);
+      margin-bottom: 0.75rem;
+      position: relative;
+    }
+
+    .cta-box > p {
+      color: var(--text-secondary);
+      max-width: 480px;
+      margin: 0 auto 1.75rem;
+      position: relative;
+      font-size: clamp(0.88rem, 2vw, 1rem);
+    }
+
+    .contrib-types {
+      display: flex;
+      justify-content: center;
+      gap: 1rem 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 2rem;
+      position: relative;
+    }
+
+    .contrib-type {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+    }
+
+    .contrib-type .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--pink);
+      opacity: 0.6;
+    }
+
+    /* ── Footer ──────────────────────────────────────────────── */
+    .footer {
+      padding: 2.5rem 1.25rem calc(2.5rem + var(--safe-bottom));
+      text-align: center;
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .footer-dot {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--pink);
+      margin: 0 auto 0.85rem;
+      box-shadow: 0 0 20px var(--pink-glow);
+      opacity: 0.7;
+    }
+
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.25rem;
+      margin-bottom: 0.85rem;
+      flex-wrap: wrap;
+    }
+
+    .footer-links a {
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+    }
+
+    .footer-links a:hover { color: var(--text-primary); }
+
+    .footer-credit {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+
+    /* ── Scroll Reveal ───────────────────────────────────────── */
+    .reveal {
+      opacity: 0;
+      transform: translateY(20px);
+      transition: opacity 0.7s var(--ease-out-expo), transform 0.7s var(--ease-out-expo);
+    }
+
+    .reveal.visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    /* ── Reduced Motion ──────────────────────────────────────── */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+      html { scroll-behavior: auto; }
+      .reveal { opacity: 1; transform: none; }
+      .gradient-divider { animation: none; }
+      .hero-canvas { display: none; }
+    }
+
+    /* ── Tablet (640px+) ─────────────────────────────────────── */
+    @media (min-width: 640px) {
+      .section { padding: 5rem 2rem; }
+      .cta-section { padding: 4rem 2rem; }
+      .nav { padding: 0 2rem; }
+      .hero { padding: calc(100px + var(--safe-top)) 2rem 70px; }
+      .recipe-grid { grid-template-columns: repeat(2, 1fr); }
+      .quickstart-steps { grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+      .docs-grid { grid-template-columns: repeat(2, 1fr); }
+      .cta-box { padding: 3.5rem 2.5rem; }
+      .code-block { font-size: 0.8rem; padding: 1rem 1.25rem; }
+      .recipe-card { padding: 1.75rem; }
+      .step { padding: 1.75rem; }
+    }
+
+    /* ── Desktop (768px+) ────────────────────────────────────── */
+    @media (min-width: 768px) {
+      .nav-mobile-toggle { display: none !important; }
+      .nav-links { display: flex !important; }
+
+      .hero-logo { width: 88px; height: 88px; margin-bottom: 2rem; }
+      .hero-tagline { margin-bottom: 2.5rem; }
+      .hero-actions { margin-bottom: 2.5rem; }
+      .section { padding: 6rem 2rem; }
+      .section-desc { margin-bottom: 3rem; }
+    }
+
+    /* ── Large Desktop (1024px+) ─────────────────────────────── */
+    @media (min-width: 1024px) {
+      .docs-grid { grid-template-columns: repeat(3, 1fr); }
+      .recipe-grid { grid-template-columns: repeat(2, 1fr); gap: 1.25rem; }
+      .cta-box { padding: 4rem; }
+
+      .recipe-card {
+        transition: border-color 0.3s, transform 0.3s var(--ease-out-expo), box-shadow 0.3s;
+      }
+      .recipe-card:hover {
+        border-color: var(--border-hover);
+        transform: translateY(-3px);
+        box-shadow: 0 12px 40px rgba(230, 0, 122, 0.08);
+      }
+      .recipe-card:hover::before { opacity: 1; }
+      .doc-card {
+        transition: border-color 0.3s, transform 0.3s var(--ease-out-expo);
+      }
+      .doc-card:hover {
+        border-color: var(--border-hover);
+        transform: translateY(-2px);
+        opacity: 1;
+      }
+    }
+
+    /* ── Mobile-only (<640px) ────────────────────────────────── */
+    @media (max-width: 639px) {
+      .nav-links { display: none; }
+      .nav-mobile-toggle { display: flex; }
+
+      .nav-links.open {
+        display: flex;
+        flex-direction: column;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: var(--bg-primary);
+        padding: calc(80px + var(--safe-top)) 2rem var(--safe-bottom);
+        gap: 0;
+        z-index: 98;
+        overflow-y: auto;
+        animation: nav-slide-in 0.3s var(--ease-out-expo);
+      }
+
+      .nav-links.open li {
+        border-bottom: 1px solid var(--border-subtle);
+      }
+
+      .nav-links.open li:last-child { border-bottom: none; }
+
+      .nav-links.open a,
+      .nav-links.open button {
+        width: 100%;
+        justify-content: flex-start;
+        font-size: 1.1rem;
+        padding: 1rem 0;
+        min-height: 56px;
+      }
+
+      .nav-links.open .theme-toggle {
+        width: 100%;
+        border: none;
+        justify-content: flex-start;
+        padding: 1rem 0;
+        font-size: 1.1rem;
+        gap: 0.5rem;
+      }
+
+      .nav-links.open .theme-toggle::after {
+        content: 'Toggle theme';
+        font-family: var(--font-body);
+        font-size: 1.1rem;
+        font-weight: 500;
+        color: var(--text-secondary);
+      }
+
+      .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+        padding: 0 0.5rem;
+      }
+    }
+
+    @keyframes nav-slide-in {
+      from { opacity: 0; transform: translateY(-10px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* ── PWA Install Banner ──────────────────────────────────── */
+    .install-banner {
+      display: none;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 200;
+      padding: 0.85rem max(1.25rem, var(--safe-left));
+      padding-bottom: max(0.85rem, var(--safe-bottom));
+      background: var(--bg-card);
+      border-top: 1px solid var(--border-medium);
+      backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
+      animation: banner-slide-up 0.4s var(--ease-out-expo);
+    }
+
+    .install-banner.visible { display: block; }
+
+    .install-banner-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 0.85rem;
+    }
+
+    .install-banner-icon {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      background: var(--pink);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .install-banner-icon svg {
+      width: 20px;
+      height: 20px;
+      fill: #fff;
+    }
+
+    .install-banner-text {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .install-banner-text strong {
+      display: block;
+      font-family: var(--font-display);
+      font-size: 0.88rem;
+      font-weight: 700;
+      margin-bottom: 0.1rem;
+    }
+
+    .install-banner-text span {
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+    }
+
+    .install-banner-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-shrink: 0;
+    }
+
+    .install-btn {
+      background: var(--pink);
+      color: #fff;
+      border: none;
+      padding: 0.5rem 1.1rem;
+      border-radius: 8px;
+      font-family: var(--font-body);
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+      min-height: 40px;
+      transition: opacity 0.2s;
+    }
+
+    .install-btn:active { opacity: 0.85; }
+
+    .install-dismiss {
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-size: 1.25rem;
+      cursor: pointer;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      transition: color 0.2s;
+    }
+
+    .install-dismiss:hover { color: var(--text-secondary); }
+
+    @keyframes banner-slide-up {
+      from { transform: translateY(100%); }
+      to { transform: translateY(0); }
+    }
+
+    /* When banner is visible, add footer padding so content isn't hidden */
+    body.has-install-banner .footer {
+      padding-bottom: calc(5rem + var(--safe-bottom));
+    }
+
+    @media (max-width: 639px) {
+      .install-banner-text span { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Mobile Nav Overlay -->
+  <div class="nav-overlay" id="navOverlay"></div>
+
+  <!-- Navigation -->
+  <nav class="nav" id="nav">
+    <a href="#" class="nav-brand">
+      <span class="nav-dot"></span>
+      Polkadot Cookbook
+    </a>
+    <button class="nav-mobile-toggle" id="mobileToggle" aria-label="Toggle menu" aria-expanded="false">
+      <span id="menuIcon">&#9776;</span>
+    </button>
+    <ul class="nav-links" id="navLinks">
+      <li><a href="#recipes">Recipes</a></li>
+      <li><a href="#quickstart">Quick Start</a></li>
+      <li><a href="#docs">Docs</a></li>
+      <li><a href="#contributing">Contributing</a></li>
+      <li>
+        <a href="https://github.com/polkadot-developers/polkadot-cookbook" class="gh-link" aria-label="GitHub" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </li>
+      <li>
+        <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+          <span id="themeIcon">&#9790;</span>
+        </button>
+      </li>
+    </ul>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <canvas class="hero-canvas" id="particleCanvas"></canvas>
+    <div class="hero-gradient"></div>
+    <div class="hero-content">
+      <div class="hero-logo">
+        <svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Polkadot Cookbook logo">
+          <defs>
+            <style>
+              @keyframes pc{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.05);opacity:.9}}
+              @keyframes pg{0%,100%{filter:drop-shadow(0 0 8px rgba(230,0,122,.4))}50%{filter:drop-shadow(0 0 20px rgba(230,0,122,.8))}}
+              .cd{animation:pc 2s ease-in-out infinite,pg 2s ease-in-out infinite;transform-origin:center}
+            </style>
+          </defs>
+          <circle cx="100" cy="100" r="95" fill="var(--bg-primary)" opacity="0.3"/>
+          <circle class="cd" cx="100" cy="100" r="35" fill="#E6007A"/>
+          <circle cx="100" cy="40" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin="0s"/></circle>
+          <circle cx="138.3" cy="60" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin=".25s"/></circle>
+          <circle cx="154.6" cy="100" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin=".5s"/></circle>
+          <circle cx="138.3" cy="140" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin=".75s"/></circle>
+          <circle cx="100" cy="160" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin="1s"/></circle>
+          <circle cx="61.7" cy="140" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin="1.25s"/></circle>
+          <circle cx="45.4" cy="100" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin="1.5s"/></circle>
+          <circle cx="61.7" cy="60" r="8" fill="#E6007A" opacity="0.8"><animate attributeName="opacity" values=".8;.4;.8" dur="2s" repeatCount="indefinite" begin="1.75s"/></circle>
+          <g stroke="#E6007A" stroke-width="1.5" opacity="0.25" fill="none">
+            <line x1="100" y1="65" x2="100" y2="40"/><line x1="124.6" y1="75.4" x2="138.3" y2="60"/>
+            <line x1="135" y1="100" x2="154.6" y2="100"/><line x1="124.6" y1="124.6" x2="138.3" y2="140"/>
+            <line x1="100" y1="135" x2="100" y2="160"/><line x1="75.4" y1="124.6" x2="61.7" y2="140"/>
+            <line x1="65" y1="100" x2="45.4" y2="100"/><line x1="75.4" y1="75.4" x2="61.7" y2="60"/>
+          </g>
+        </svg>
+      </div>
+      <h1 class="hero-title">Polkadot <span class="accent">Cookbook</span></h1>
+      <p class="hero-tagline">Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications.</p>
+      <div class="hero-actions">
+        <a href="#recipes" class="btn btn-primary">Browse Recipes</a>
+        <a href="#quickstart" class="btn btn-secondary">Quick Start</a>
+      </div>
+      <div class="hero-badges">
+        <img src="https://img.shields.io/badge/License-MIT%20%2F%20Apache%202.0-11116B.svg?style=flat-square" alt="License" width="168" height="22" loading="lazy">
+        <img src="https://img.shields.io/github/actions/workflow/status/polkadot-developers/polkadot-cookbook/test-sdk.yml?label=SDK&color=E6007A&style=flat-square" alt="SDK Status" width="90" height="22" loading="lazy">
+        <img src="https://img.shields.io/badge/CLI-dot%20v0.5.0-E6007A?style=flat-square&logo=rust&logoColor=white" alt="CLI" width="116" height="22" loading="lazy">
+      </div>
+    </div>
+  </section>
+
+  <div class="gradient-divider"></div>
+
+  <!-- Recipes -->
+  <section class="section" id="recipes">
+    <div class="reveal">
+      <p class="section-label">// Recipes</p>
+      <h2 class="section-title">Build across every pathway</h2>
+      <p class="section-desc">Each recipe's source code lives in its own external repository. Test harnesses here automatically clone, build, and verify each one.</p>
+    </div>
+    <div class="recipe-grid">
+
+      <div class="recipe-card reveal">
+        <div class="recipe-card-icon">
+          <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+        </div>
+        <h3>Pallets</h3>
+        <p>Build custom parachains with FRAME pallets, runtime logic, and PAPI integration testing.</p>
+        <div class="recipe-links">
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/parachains/parachain-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            parachain-example
+          </a>
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/pallets/pallet-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            pallet-example
+          </a>
+        </div>
+      </div>
+
+      <div class="recipe-card reveal">
+        <div class="recipe-card-icon">
+          <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8Z"/><path d="M14 2v6h6"/><path d="M10 13l-2 2 2 2M14 13l2 2-2 2"/></svg>
+        </div>
+        <h3>Contracts</h3>
+        <p>Deploy and interact with Solidity smart contracts on Polkadot parachains using Hardhat.</p>
+        <div class="recipe-links">
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/contracts/contracts-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            contracts-example
+          </a>
+        </div>
+      </div>
+
+      <div class="recipe-card reveal">
+        <div class="recipe-card-icon">
+          <svg viewBox="0 0 24 24"><path d="M22 2L11 13M22 2l-7 20-3-9-9-3z"/></svg>
+        </div>
+        <h3>Transactions</h3>
+        <p>Single-chain transaction submission and state queries using the Polkadot API.</p>
+        <div class="recipe-links">
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/transactions/transaction-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            transaction-example
+          </a>
+        </div>
+      </div>
+
+      <div class="recipe-card reveal">
+        <div class="recipe-card-icon">
+          <svg viewBox="0 0 24 24"><circle cx="7" cy="12" r="4"/><circle cx="17" cy="12" r="4"/><path d="M11 12h2"/></svg>
+        </div>
+        <h3>XCM</h3>
+        <p>Cross-chain asset transfers and messaging between parachains with Chopsticks testing.</p>
+        <div class="recipe-links">
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/cross-chain-transactions/cross-chain-transaction-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            cross-chain-transaction-example
+          </a>
+        </div>
+      </div>
+
+      <div class="recipe-card reveal">
+        <div class="recipe-card-icon">
+          <svg viewBox="0 0 24 24"><circle cx="12" cy="5" r="2.5"/><circle cx="5" cy="19" r="2.5"/><circle cx="19" cy="19" r="2.5"/><path d="M12 7.5V13M10 14.5L7 17M14 14.5l3 2.5"/></svg>
+        </div>
+        <h3>Networks</h3>
+        <p>Testing infrastructure with Zombienet and Chopsticks for local network development.</p>
+        <div class="recipe-links">
+          <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/networks/network-example" class="recipe-link" target="_blank" rel="noopener">
+            <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
+            network-example
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <div class="gradient-divider"></div>
+
+  <!-- Quick Start -->
+  <section class="section" id="quickstart">
+    <div class="reveal">
+      <p class="section-label">// Quick Start</p>
+      <h2 class="section-title">Up and running in minutes</h2>
+      <p class="section-desc">Install the CLI, pick a recipe, and start building.</p>
+    </div>
+    <div class="quickstart-steps">
+      <div class="step reveal">
+        <p class="step-number">Step 01</p>
+        <h3>Install the CLI</h3>
+        <p>One command to install the <code style="font-family:var(--font-mono);font-size:.85em;color:var(--pink)">dot</code> CLI tool.</p>
+        <div class="code-block" id="installCode">
+          <button class="copy-btn" onclick="copyCode('installCmd')" title="Copy">&#x2398;</button>
+          <span id="installCmd"><span class="prompt">$</span> curl -fsSL https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/master/install.sh | bash</span>
+        </div>
+      </div>
+      <div class="step reveal">
+        <p class="step-number">Step 02</p>
+        <h3>Run a recipe</h3>
+        <p>Clone a recipe harness and run the tests to verify it works.</p>
+        <div class="code-block" id="recipeCode">
+          <button class="copy-btn" onclick="copyCode('recipeCmd')" title="Copy">&#x2398;</button>
+          <span id="recipeCmd"><span class="prompt">$</span> cd recipes/contracts/contracts-example
+<span class="prompt">$</span> npm ci <span class="comment"># Install harness deps</span>
+<span class="prompt">$</span> npm test <span class="comment"># Clone, build &amp; test</span></span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div class="gradient-divider"></div>
+
+  <!-- Documentation -->
+  <section class="section" id="docs">
+    <div class="reveal">
+      <p class="section-label">// Documentation</p>
+      <h2 class="section-title">Everything you need to know</h2>
+      <p class="section-desc">Guides organized by role, from first-time users to maintainers.</p>
+    </div>
+    <div class="docs-grid">
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/getting-started" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Getting Started</h3>
+        <p>Installation, first project tutorial, basic concepts and workflow.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/contributors" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Contributors</h3>
+        <p>Recipe development patterns, testing standards, and commit conventions.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/developers" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Developers</h3>
+        <p>System architecture, SDK programmatic usage, and CLI reference.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/maintainers" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Maintainers</h3>
+        <p>Release process, GitHub Actions workflows, and version management.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/automation" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Automation</h3>
+        <p>Pre-commit hooks, CI/CD workflows, and testing configuration.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/docs/reference" class="doc-card reveal" target="_blank" rel="noopener">
+        <h3>Reference</h3>
+        <p>Manifest schema, recipe config spec, and security guidelines.</p>
+        <span class="doc-arrow">&rarr;</span>
+      </a>
+    </div>
+  </section>
+
+  <div class="gradient-divider"></div>
+
+  <!-- Contributing -->
+  <section class="cta-section" id="contributing">
+    <div class="cta-box reveal">
+      <h2>Help build the <span class="accent">Polkadot Cookbook</span></h2>
+      <p>Every recipe helps the next developer build faster. Share your knowledge with the ecosystem.</p>
+      <div class="contrib-types">
+        <span class="contrib-type"><span class="dot"></span> Recipes</span>
+        <span class="contrib-type"><span class="dot"></span> Bug Reports</span>
+        <span class="contrib-type"><span class="dot"></span> Features</span>
+        <span class="contrib-type"><span class="dot"></span> Documentation</span>
+      </div>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/blob/master/CONTRIBUTING.md" class="btn btn-primary" target="_blank" rel="noopener">Start Contributing</a>
+    </div>
+  </section>
+
+  <!-- PWA Install Banner -->
+  <div class="install-banner" id="installBanner" role="complementary" aria-label="Install app">
+    <div class="install-banner-inner">
+      <div class="install-banner-icon">
+        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/></svg>
+      </div>
+      <div class="install-banner-text">
+        <strong>Polkadot Cookbook</strong>
+        <span id="installSubtext">Install for quick access</span>
+      </div>
+      <div class="install-banner-actions">
+        <button class="install-btn" id="installBtn">Install</button>
+        <button class="install-dismiss" id="installDismiss" aria-label="Dismiss">&#10005;</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-dot"></div>
+    <div class="footer-links">
+      <a href="#recipes">Recipes</a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook/issues" target="_blank" rel="noopener">Issues</a>
+      <a href="https://github.com/polkadot-developers/polkadot-cookbook" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p class="footer-credit">Built by <a href="https://github.com/polkadot-developers">Polkadot Developers</a> &middot; MIT / Apache 2.0</p>
+  </footer>
+
+  <script>
+    /* ── Particle Network (disabled on mobile + reduced motion) ── */
+    (function() {
+      var isMobile = window.innerWidth < 640;
+      var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var canvas = document.getElementById('particleCanvas');
+      if (isMobile || prefersReduced) {
+        canvas.style.display = 'none';
+        return;
+      }
+
+      var ctx = canvas.getContext('2d');
+      var particles = [];
+      var w, h, dpr, raf;
+
+      function resize() {
+        dpr = window.devicePixelRatio || 1;
+        var rect = canvas.parentElement.getBoundingClientRect();
+        w = rect.width;
+        h = rect.height;
+        canvas.width = w * dpr;
+        canvas.height = h * dpr;
+        canvas.style.width = w + 'px';
+        canvas.style.height = h + 'px';
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      }
+
+      function init() {
+        resize();
+        particles = [];
+        var count = Math.min(50, Math.floor(w * h / 20000));
+        for (var i = 0; i < count; i++) {
+          particles.push({
+            x: Math.random() * w,
+            y: Math.random() * h,
+            vx: (Math.random() - 0.5) * 0.2,
+            vy: (Math.random() - 0.5) * 0.2,
+            r: Math.random() * 1.6 + 0.5
+          });
+        }
+      }
+
+      function draw() {
+        ctx.clearRect(0, 0, w, h);
+        var isDark = document.documentElement.getAttribute('data-theme') !== 'light';
+        var dotA = isDark ? 0.4 : 0.2;
+        var lineA = isDark ? 0.1 : 0.05;
+
+        for (var i = 0; i < particles.length; i++) {
+          var p = particles[i];
+          p.x += p.vx;
+          p.y += p.vy;
+          if (p.x < 0 || p.x > w) p.vx *= -1;
+          if (p.y < 0 || p.y > h) p.vy *= -1;
+
+          ctx.beginPath();
+          ctx.arc(p.x, p.y, p.r, 0, 6.283);
+          ctx.fillStyle = 'rgba(230,0,122,' + dotA + ')';
+          ctx.fill();
+
+          for (var j = i + 1; j < particles.length; j++) {
+            var q = particles[j];
+            var dx = p.x - q.x;
+            var dy = p.y - q.y;
+            var d2 = dx * dx + dy * dy;
+            if (d2 < 22500) {
+              ctx.beginPath();
+              ctx.moveTo(p.x, p.y);
+              ctx.lineTo(q.x, q.y);
+              ctx.strokeStyle = 'rgba(230,0,122,' + (lineA * (1 - d2 / 22500)) + ')';
+              ctx.lineWidth = 0.5;
+              ctx.stroke();
+            }
+          }
+        }
+        raf = requestAnimationFrame(draw);
+      }
+
+      init();
+      draw();
+
+      var resizeTimer;
+      window.addEventListener('resize', function() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(init, 200);
+      }, { passive: true });
+
+      /* Pause when tab hidden */
+      document.addEventListener('visibilitychange', function() {
+        if (document.hidden) {
+          cancelAnimationFrame(raf);
+        } else {
+          draw();
+        }
+      });
+    })();
+
+    /* ── Scroll Reveal ───────────────────────────────────── */
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      var observer = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.06, rootMargin: '0px 0px -40px 0px' });
+
+      document.querySelectorAll('.reveal').forEach(function(el) {
+        observer.observe(el);
+      });
+    }
+
+    /* ── Nav Background on Scroll ────────────────────────── */
+    var nav = document.getElementById('nav');
+    var scrollTick = false;
+    window.addEventListener('scroll', function() {
+      if (!scrollTick) {
+        requestAnimationFrame(function() {
+          nav.classList.toggle('scrolled', window.scrollY > 40);
+          scrollTick = false;
+        });
+        scrollTick = true;
+      }
+    }, { passive: true });
+
+    /* ── Mobile Nav Toggle ───────────────────────────────── */
+    var mobileToggle = document.getElementById('mobileToggle');
+    var navLinks = document.getElementById('navLinks');
+    var navOverlay = document.getElementById('navOverlay');
+    var menuIcon = document.getElementById('menuIcon');
+
+    function closeNav() {
+      navLinks.classList.remove('open');
+      navOverlay.classList.remove('open');
+      mobileToggle.setAttribute('aria-expanded', 'false');
+      menuIcon.innerHTML = '&#9776;';
+      document.body.style.overflow = '';
+    }
+
+    function openNav() {
+      navLinks.classList.add('open');
+      navOverlay.classList.add('open');
+      mobileToggle.setAttribute('aria-expanded', 'true');
+      menuIcon.innerHTML = '&#10005;';
+      document.body.style.overflow = 'hidden';
+    }
+
+    mobileToggle.addEventListener('click', function() {
+      if (navLinks.classList.contains('open')) {
+        closeNav();
+      } else {
+        openNav();
+      }
+    });
+
+    navOverlay.addEventListener('click', closeNav);
+
+    /* Close mobile nav on link click */
+    navLinks.querySelectorAll('a[href^="#"]').forEach(function(link) {
+      link.addEventListener('click', closeNav);
+    });
+
+    /* ── Theme Toggle ────────────────────────────────────── */
+    var html = document.documentElement;
+    var themeIcon = document.getElementById('themeIcon');
+    var stored = localStorage.getItem('theme');
+    if (stored) {
+      html.setAttribute('data-theme', stored);
+      themeIcon.textContent = stored === 'light' ? '\u2600' : '\u263E';
+    }
+
+    document.getElementById('themeToggle').addEventListener('click', function() {
+      var current = html.getAttribute('data-theme');
+      var next = current === 'dark' ? 'light' : 'dark';
+      html.setAttribute('data-theme', next);
+      localStorage.setItem('theme', next);
+      themeIcon.textContent = next === 'light' ? '\u2600' : '\u263E';
+    });
+
+    /* ── Copy Code ───────────────────────────────────────── */
+    function copyCode(id) {
+      var el = document.getElementById(id);
+      var text = el.textContent.replace(/^\$ /gm, '').replace(/# .+$/gm, '').trim();
+      navigator.clipboard.writeText(text).then(function() {
+        var btn = el.closest('.code-block').querySelector('.copy-btn');
+        btn.textContent = '\u2713';
+        btn.classList.add('copied');
+        setTimeout(function() {
+          btn.textContent = '\u2398';
+          btn.classList.remove('copied');
+        }, 1500);
+      });
+    }
+
+    /* ── PWA Install Banner ──────────────────────────────── */
+    (function() {
+      var banner = document.getElementById('installBanner');
+      var installBtn = document.getElementById('installBtn');
+      var dismissBtn = document.getElementById('installDismiss');
+      var subtext = document.getElementById('installSubtext');
+      var deferredPrompt = null;
+
+      /* Don't show if already installed or dismissed recently */
+      var isStandalone = window.matchMedia('(display-mode: standalone)').matches
+        || window.navigator.standalone === true;
+      var dismissed = localStorage.getItem('pwa-dismiss');
+      var dismissedRecently = dismissed && (Date.now() - parseInt(dismissed, 10)) < 7 * 86400000;
+
+      if (isStandalone || dismissedRecently) return;
+
+      function showBanner() {
+        banner.classList.add('visible');
+        document.body.classList.add('has-install-banner');
+      }
+
+      function hideBanner() {
+        banner.classList.remove('visible');
+        document.body.classList.remove('has-install-banner');
+        localStorage.setItem('pwa-dismiss', String(Date.now()));
+      }
+
+      dismissBtn.addEventListener('click', hideBanner);
+
+      /* Chrome/Edge/Android: native install prompt */
+      window.addEventListener('beforeinstallprompt', function(e) {
+        e.preventDefault();
+        deferredPrompt = e;
+        subtext.textContent = 'Install for quick access';
+        installBtn.textContent = 'Install';
+        showBanner();
+      });
+
+      installBtn.addEventListener('click', function() {
+        if (deferredPrompt) {
+          deferredPrompt.prompt();
+          deferredPrompt.userChoice.then(function(result) {
+            deferredPrompt = null;
+            hideBanner();
+          });
+        } else {
+          /* iOS: open share sheet instructions */
+          hideBanner();
+        }
+      });
+
+      /* iOS Safari detection */
+      var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent)
+        || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      var isSafari = /Safari/.test(navigator.userAgent)
+        && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(navigator.userAgent);
+
+      if (isIOS && isSafari && !isStandalone) {
+        subtext.textContent = 'Tap Share then "Add to Home Screen"';
+        installBtn.textContent = 'How to install';
+        installBtn.addEventListener('click', function() {
+          alert('To install:\n\n1. Tap the Share button (box with arrow)\n2. Scroll down and tap "Add to Home Screen"\n3. Tap "Add"');
+        }, { once: true });
+        setTimeout(showBanner, 2000);
+      }
+
+      /* Hide when app gets installed */
+      window.addEventListener('appinstalled', hideBanner);
+    })();
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Replace default Jekyll markdown rendering with a custom single-page dark-themed site
- Mobile-first responsive design (1-col → 2-col → 3-col grids across breakpoints)
- Polkadot branding: Plus Jakarta Sans typography, particle network animation, `#E6007A` pink + `#11116B` deep blue color palette
- PWA manifest with install banner (native on Chrome/Android, instructions on iOS Safari)
- Particle canvas disabled on mobile for battery savings, paused when tab hidden
- `prefers-reduced-motion` support disables all animations
- Safe area insets for notched devices, 44px+ touch targets throughout

## Test plan
- [ ] Verify site renders at https://polkadot-developers.github.io/polkadot-cookbook/ after merge
- [ ] Test mobile responsiveness using Chrome DevTools device toolbar (iPhone SE, Pixel 7, iPad)
- [ ] Verify dark/light theme toggle works and persists via localStorage
- [ ] Confirm particle canvas is hidden on mobile viewports (<640px)
- [ ] Test PWA install banner appears on Android Chrome (requires HTTPS)
- [ ] Verify all recipe and documentation links point to correct GitHub paths