### PR TITLE
fix: code block overflow on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -380,6 +380,7 @@
       padding: 4rem 1.25rem;
       max-width: 1080px;
       margin: 0 auto;
+      overflow: hidden;
     }
 
     .section-label {
@@ -543,6 +544,8 @@
       border: 1px solid var(--border-subtle);
       border-radius: 14px;
       padding: 1.5rem;
+      min-width: 0;
+      overflow: hidden;
     }
 
     .step-number {


### PR DESCRIPTION
## Summary
- Fix long `curl` URL in Quick Start section overflowing viewport on mobile
- Add `min-width: 0` + `overflow: hidden` to `.step` grid children
- Add `overflow: hidden` to `.section` container

## Test plan
- [ ] Verify Quick Start code blocks stay within viewport on mobile (iPhone SE, Pixel 7)
- [ ] Confirm horizontal scroll works inside code blocks for long commands