### PR TITLE
fix: manifest start_url and deprecated meta tag

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Practical, tested recipes for building on Polkadot. Build runtime logic, smart contracts, dApps, and cross-chain applications with working code examples.">
   <meta name="theme-color" content="#08080d" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#fafafc" media="(prefers-color-scheme: light)">
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta property="og:title" content="Polkadot Cookbook">
   <meta property="og:description" content="Practical, tested recipes for building on Polkadot">
@@ -15,7 +15,7 @@
   <meta property="og:url" content="https://polkadot-developers.github.io/polkadot-cookbook/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='40' fill='%23E6007A'/></svg>">
   <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 180 180'><rect width='180' height='180' rx='40' fill='%2308080d'/><circle cx='90' cy='90' r='50' fill='%23E6007A'/></svg>">
-  <link rel="manifest" href="data:application/manifest+json,%7B%22name%22%3A%22Polkadot%20Cookbook%22%2C%22short_name%22%3A%22Cookbook%22%2C%22start_url%22%3A%22.%22%2C%22display%22%3A%22standalone%22%2C%22background_color%22%3A%22%2308080d%22%2C%22theme_color%22%3A%22%23E6007A%22%2C%22description%22%3A%22Practical%2C%20tested%20recipes%20for%20building%20on%20Polkadot%22%7D">
+  <link rel="manifest" href="manifest.json">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Polkadot Cookbook",
+  "short_name": "Cookbook",
+  "start_url": "/polkadot-cookbook/",
+  "display": "standalone",
+  "background_color": "#08080d",
+  "theme_color": "#E6007A",
+  "description": "Practical, tested recipes for building on Polkadot"
+}


### PR DESCRIPTION
## Summary
- Replace inline data URI manifest with proper `docs/manifest.json` file (fixes invalid `start_url` warning)
- Replace deprecated `apple-mobile-web-app-capable` with `mobile-web-app-capable`

## Test plan
- [ ] Verify no console warnings on the deployed site
- [ ] Check Application > Manifest in DevTools shows valid manifest