### PR TITLE
fix: contributing section layout on mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -705,10 +705,10 @@
     }
 
     .contrib-types {
-      display: flex;
+      display: grid;
+      grid-template-columns: repeat(2, auto);
       justify-content: center;
-      gap: 1rem 1.5rem;
-      flex-wrap: wrap;
+      gap: 0.6rem 1.5rem;
       margin-bottom: 2rem;
       position: relative;
     }


### PR DESCRIPTION
## Summary
- Switch contrib types from `flex-wrap` to `grid-template-columns: repeat(2, auto)` for a clean 2x2 layout instead of awkward 3+1 wrapping on mobile

## Test plan
- [ ] Verify Recipes/Bug Reports on first row, Features/Documentation on second row on mobile