### PR TITLE
fix: quickstart code blocks stretching to equal grid height

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -555,6 +555,7 @@
       display: grid;
       grid-template-columns: 1fr;
       gap: 1rem;
+      align-items: start;
     }
 
     .step {


### PR DESCRIPTION
## Summary
- Add `align-items: start` to the quickstart-steps grid so each step card sizes to its own content instead of stretching to match the tallest card

## Test plan
- [ ] Verify the Quick Start code blocks no longer have excessive vertical space in light/dark mode