### PR TITLE
fix: make hero logo larger and position higher

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -251,7 +251,7 @@
       align-items: center;
       justify-content: center;
       text-align: center;
-      padding: calc(80px + var(--safe-top)) 1.25rem 60px;
+      padding: calc(80px + var(--safe-top)) 1.25rem 120px;
       overflow: hidden;
     }
 
@@ -284,9 +284,9 @@
     }
 
     .hero-logo {
-      width: 72px;
-      height: 72px;
-      margin: 0 auto 1.5rem;
+      width: 120px;
+      height: 120px;
+      margin: 0 auto 2rem;
       animation: hero-fade-in 1s var(--ease-out-expo) both;
     }
 
@@ -833,7 +833,7 @@
       .nav-mobile-toggle { display: none !important; }
       .nav-links { display: flex !important; }
 
-      .hero-logo { width: 88px; height: 88px; margin-bottom: 2rem; }
+      .hero-logo { width: 160px; height: 160px; margin-bottom: 2.5rem; }
       .hero-tagline { margin-bottom: 2.5rem; }
       .hero-actions { margin-bottom: 2.5rem; }
       .section { padding: 6rem 2rem; }


### PR DESCRIPTION
## Summary
- Increase hero logo from 72px/88px to 120px/160px (mobile/desktop)
- Add more bottom padding to hero so content sits above vertical center

## Test plan
- [ ] Verify logo is larger and positioned higher on both mobile and desktop