### PR TITLE
fix: clarify site copy and fix README permalink routing

### DIFF
--- a/docs/automation/README.md
+++ b/docs/automation/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Automation & CI/CD"
+permalink: /automation/
 ---
 
 # Automation & CI/CD

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Contributors Guide"
+permalink: /contributors/
 ---
 
 # Contributors Guide

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Developers Guide"
+permalink: /developers/
 ---
 
 # Developers Guide

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Getting Started"
+permalink: /getting-started/
 ---
 
 # Getting Started with Polkadot Cookbook

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Polkadot Cookbook &mdash; Practical recipes for Polkadot development</title>
-  <meta name="description" content="Practical, tested recipes for building on Polkadot. Build runtime logic, smart contracts, dApps, and cross-chain applications with working code examples.">
+  <meta name="description" content="Build Polkadot projects with the dot CLI. Explore community-contributed recipes verified by automated test harnesses across smart contracts, parachains, transactions, XCM, and networks.">
   <meta name="theme-color" content="#08080d" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#fafafc" media="(prefers-color-scheme: light)">
   <meta name="mobile-web-app-capable" content="yes">
@@ -13,7 +13,7 @@
   <link rel="canonical" href="https://polkadot-developers.github.io/polkadot-cookbook/">
   <!-- Open Graph -->
   <meta property="og:title" content="Polkadot Cookbook">
-  <meta property="og:description" content="Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications.">
+  <meta property="og:description" content="Build Polkadot projects with the dot CLI. Explore community-contributed recipes verified by automated test harnesses.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://polkadot-developers.github.io/polkadot-cookbook/">
   <meta property="og:image" content="https://polkadot-developers.github.io/polkadot-cookbook/og-image.png">
@@ -23,7 +23,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Polkadot Cookbook">
-  <meta name="twitter:description" content="Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications.">
+  <meta name="twitter:description" content="Build Polkadot projects with the dot CLI. Explore community-contributed recipes verified by automated test harnesses.">
   <meta name="twitter:image" content="https://polkadot-developers.github.io/polkadot-cookbook/og-image.png">
   <!-- Telegram -->
   <meta name="telegram:channel" content="@polkadot">
@@ -1064,7 +1064,7 @@
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "Polkadot Cookbook",
-    "description": "Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications.",
+    "description": "Build Polkadot projects with the dot CLI. Explore community-contributed recipes verified by automated test harnesses.",
     "url": "https://polkadot-developers.github.io/polkadot-cookbook/",
     "image": "https://polkadot-developers.github.io/polkadot-cookbook/og-image.png",
     "author": {
@@ -1166,10 +1166,10 @@
           </g>
         </svg>
       </div>
-      <p class="hero-tagline">Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications.</p>
+      <p class="hero-tagline">Build Polkadot projects with the <code style="font-family:var(--font-mono);font-size:.85em;color:var(--pink)">dot</code> CLI. Explore community-contributed recipes verified by automated test harnesses.</p>
       <div class="hero-actions">
-        <a href="#recipes" class="btn btn-primary">Browse Recipes</a>
-        <a href="#quickstart" class="btn btn-secondary">Quick Start</a>
+        <a href="#quickstart" class="btn btn-primary">Build a Project</a>
+        <a href="#recipes" class="btn btn-secondary">Explore Recipes</a>
       </div>
       <div class="hero-badges">
         <img src="https://img.shields.io/badge/License-MIT%20%2F%20Apache%202.0-11116B.svg?style=flat-square" alt="License" width="168" height="22" loading="lazy">
@@ -1185,8 +1185,8 @@
   <section class="section" id="recipes">
     <div class="reveal">
       <p class="section-label">// Recipes</p>
-      <h2 class="section-title">Build across every pathway</h2>
-      <p class="section-desc">Each recipe's source code lives in its own external repository. Test harnesses here automatically clone, build, and verify each one.</p>
+      <h2 class="section-title">Verified recipes across every pathway</h2>
+      <p class="section-desc">Recipes are community-contributed code examples hosted in external repositories. Each test harness here automatically clones, builds, and verifies that the recipe works.</p>
     </div>
     <div class="recipe-grid">
 
@@ -1195,7 +1195,7 @@
           <svg viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
         </div>
         <h3>Pallets</h3>
-        <p>Build custom parachains with FRAME pallets, runtime logic, and PAPI integration testing.</p>
+        <p>Verified examples of custom parachains with FRAME pallets, runtime logic, and PAPI integration.</p>
         <div class="recipe-links">
           <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/parachains/parachain-example" class="recipe-link" target="_blank" rel="noopener">
             <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
@@ -1213,7 +1213,7 @@
           <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8Z"/><path d="M14 2v6h6"/><path d="M10 13l-2 2 2 2M14 13l2 2-2 2"/></svg>
         </div>
         <h3>Contracts</h3>
-        <p>Deploy and interact with Solidity smart contracts on Polkadot parachains using Hardhat.</p>
+        <p>Verified examples of Solidity smart contracts on Polkadot parachains using Hardhat.</p>
         <div class="recipe-links">
           <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/contracts/contracts-example" class="recipe-link" target="_blank" rel="noopener">
             <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
@@ -1227,7 +1227,7 @@
           <svg viewBox="0 0 24 24"><path d="M22 2L11 13M22 2l-7 20-3-9-9-3z"/></svg>
         </div>
         <h3>Transactions</h3>
-        <p>Single-chain transaction submission and state queries using the Polkadot API.</p>
+        <p>Verified examples of single-chain transaction submission and state queries via the Polkadot API.</p>
         <div class="recipe-links">
           <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/transactions/transaction-example" class="recipe-link" target="_blank" rel="noopener">
             <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
@@ -1241,7 +1241,7 @@
           <svg viewBox="0 0 24 24"><circle cx="7" cy="12" r="4"/><circle cx="17" cy="12" r="4"/><path d="M11 12h2"/></svg>
         </div>
         <h3>XCM</h3>
-        <p>Cross-chain asset transfers and messaging between parachains with Chopsticks testing.</p>
+        <p>Verified examples of cross-chain asset transfers and messaging between parachains.</p>
         <div class="recipe-links">
           <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/cross-chain-transactions/cross-chain-transaction-example" class="recipe-link" target="_blank" rel="noopener">
             <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
@@ -1255,7 +1255,7 @@
           <svg viewBox="0 0 24 24"><circle cx="12" cy="5" r="2.5"/><circle cx="5" cy="19" r="2.5"/><circle cx="19" cy="19" r="2.5"/><path d="M12 7.5V13M10 14.5L7 17M14 14.5l3 2.5"/></svg>
         </div>
         <h3>Networks</h3>
-        <p>Testing infrastructure with Zombienet and Chopsticks for local network development.</p>
+        <p>Verified examples of testing infrastructure with Zombienet and Chopsticks.</p>
         <div class="recipe-links">
           <a href="https://github.com/polkadot-developers/polkadot-cookbook/tree/master/recipes/networks/network-example" class="recipe-link" target="_blank" rel="noopener">
             <svg viewBox="0 0 24 24"><path d="M7 17L17 7M17 7H7M17 7v10" stroke-width="2"/></svg>
@@ -1274,7 +1274,7 @@
     <div class="reveal">
       <p class="section-label">// Quick Start</p>
       <h2 class="section-title">Up and running in minutes</h2>
-      <p class="section-desc">Install the CLI, pick a recipe, and start building.</p>
+      <p class="section-desc">Use the <code style="font-family:var(--font-mono);font-size:.85em;color:var(--pink)">dot</code> CLI to scaffold new Polkadot projects &mdash; smart contracts, parachains, and more.</p>
     </div>
     <div class="quickstart-steps">
       <div class="step reveal">
@@ -1285,11 +1285,9 @@
       </div>
       <div class="step reveal">
         <p class="step-number">Step 02</p>
-        <h3>Run a recipe</h3>
-        <p>Clone a recipe harness and run the tests to verify it works.</p>
-        <div class="code-block" id="recipeCode"><button class="copy-btn" onclick="copyCode('recipeCmd')" title="Copy">&#x2398;</button><span id="recipeCmd"><span class="prompt">$</span> cd recipes/contracts/contracts-example
-<span class="prompt">$</span> npm ci <span class="comment"># Install harness deps</span>
-<span class="prompt">$</span> npm test <span class="comment"># Clone, build &amp; test</span></span></div>
+        <h3>Create a project</h3>
+        <p>Scaffold a new Polkadot project from a template &mdash; smart contracts, parachains, and more.</p>
+        <div class="code-block" id="recipeCode"><button class="copy-btn" onclick="copyCode('recipeCmd')" title="Copy">&#x2398;</button><span id="recipeCmd"><span class="prompt">$</span> dot create --title "my-project"</span></div>
       </div>
     </div>
   </section>
@@ -1342,12 +1340,12 @@
   <!-- Contributing -->
   <section class="cta-section" id="contributing">
     <div class="cta-box reveal">
-      <h2>Help build the <span class="accent">Polkadot Cookbook</span></h2>
-      <p>Every recipe helps the next developer build faster. Share your knowledge with the ecosystem.</p>
+      <h2>Contribute to the <span class="accent">Polkadot Cookbook</span></h2>
+      <p>Have a working Polkadot project? Add a test harness so others can verify and learn from your code.</p>
       <div class="contrib-types">
-        <span class="contrib-type"><span class="dot"></span> Recipes</span>
+        <span class="contrib-type"><span class="dot"></span> Recipe Test Harnesses</span>
         <span class="contrib-type"><span class="dot"></span> Bug Reports</span>
-        <span class="contrib-type"><span class="dot"></span> Features</span>
+        <span class="contrib-type"><span class="dot"></span> CLI Features</span>
         <span class="contrib-type"><span class="dot"></span> Documentation</span>
       </div>
       <a href="https://github.com/polkadot-developers/polkadot-cookbook/blob/master/CONTRIBUTING.md" class="btn btn-primary" target="_blank" rel="noopener">Start Contributing</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,8 +1,8 @@
 # Polkadot Cookbook
 
-> Practical, tested recipes for building on Polkadot. Runtime logic, smart contracts, dApps, and cross-chain applications with working code examples.
+> Build Polkadot projects with the `dot` CLI. Explore community-contributed recipes verified by automated test harnesses across smart contracts, parachains, transactions, XCM, and networks.
 
-The Polkadot Cookbook is an open-source collection of tested recipes for building on the Polkadot network. It includes a CLI tool (`dot`), an SDK, and test harnesses that verify each recipe works end-to-end.
+The Polkadot Cookbook has two main components: (1) the `dot` CLI tool for scaffolding new Polkadot projects (smart contracts, parachains, and more across 5 pathways), and (2) a collection of community-contributed recipe test harnesses that automatically clone, build, and verify external code examples work end-to-end.
 
 ## Documentation Sections
 
@@ -17,11 +17,11 @@ The Polkadot Cookbook is an open-source collection of tested recipes for buildin
 
 The cookbook organizes recipes into pathways:
 
-- **Pallets** — Build custom parachains with FRAME pallets and PAPI integration testing
-- **Contracts** — Deploy and interact with Solidity smart contracts using Hardhat
-- **Transactions** — Single-chain transaction submission and state queries via Polkadot API (PAPI)
-- **XCM (Cross-Chain Messaging)** — Cross-chain asset transfers between parachains with Chopsticks testing
-- **Networks** — Testing infrastructure with Zombienet and Chopsticks
+- **Pallets** — Verified examples of custom parachains with FRAME pallets and PAPI integration
+- **Contracts** — Verified examples of Solidity smart contracts on Polkadot parachains using Hardhat
+- **Transactions** — Verified examples of single-chain transaction submission and state queries via Polkadot API (PAPI)
+- **XCM (Cross-Chain Messaging)** — Verified examples of cross-chain asset transfers between parachains
+- **Networks** — Verified examples of testing infrastructure with Zombienet and Chopsticks
 
 ## CLI Tool
 
@@ -43,9 +43,9 @@ dot test
 - `dot/cli/` — Rust CLI binary (interactive terminal, Git integration)
 - `dot/sdk/` — Rust core library (async-first, no terminal deps, 80%+ test coverage)
 - `dot/sdk/templates/` — Embedded templates used by `dot create`
-- `recipes/{pathway}/{recipe-name}/` — Test harnesses (clone external repos, verify they work)
+- `recipes/{pathway}/{recipe-name}/` — Test harnesses that clone, build, and verify community-contributed external repos
 
-Each recipe test harness follows a standard structure:
+Each recipe is an externally-owned project. The cookbook only contains test harnesses that verify these external repos. Each test harness follows a standard structure:
 - `package.json` + `vitest.config.ts` + `tests/recipe.test.ts`
 - Tests clone an external repo at a pinned version, install dependencies, build, and run tests
 

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Maintainers Guide"
+permalink: /maintainers/
 ---
 
 # Maintainers Guide

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -5,5 +5,5 @@
   "display": "standalone",
   "background_color": "#08080d",
   "theme_color": "#E6007A",
-  "description": "Practical, tested recipes for building on Polkadot"
+  "description": "Build Polkadot projects with the dot CLI. Explore community-contributed recipes verified by automated test harnesses."
 }

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,7 @@
 ---
 layout: doc
 title: "Reference Documentation"
+permalink: /reference/
 ---
 
 # Reference Documentation

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,4 +1,4 @@
-var CACHE = 'cookbook-v2';
+var CACHE = 'cookbook-v3';
 var PRECACHE = [
   '/polkadot-cookbook/',
   '/polkadot-cookbook/manifest.json'


### PR DESCRIPTION
## Summary
- Rewrite site copy to clearly distinguish the three use cases:
  1. **`dot` CLI** — scaffolds new Polkadot projects (smart contracts, parachains, etc.)
  2. **Recipes** — test harnesses that verify community-contributed external repos work
  3. **Contributing** — add a test harness for your externally-owned Polkadot project
- Add `permalink` front matter to all 6 section `README.md` files so they render as directory indexes (`/contributors/` instead of `/contributors/README.html`) — fixes 404s on section landing pages
- Update meta descriptions, OG/Twitter tags, JSON-LD, manifest.json, and llms.txt
- Bump service worker cache to v3

## Test plan
- [ ] Verify `/polkadot-cookbook/contributors/` returns 200 (was 404)
- [ ] Verify all 6 section index pages load: getting-started, contributors, developers, maintainers, automation, reference
- [ ] Verify hero tagline, quickstart, recipes, and contributing sections have correct messaging
- [ ] Verify individual doc pages still work (e.g. `/contributors/workflow`)