### PR TITLE
fix: quickstart step 01 copy to highlight 5 pathways

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1280,7 +1280,7 @@
       <div class="step reveal">
         <p class="step-number">Step 01</p>
         <h3>Install the CLI</h3>
-        <p>One command to install the <code style="font-family:var(--font-mono);font-size:.85em;color:var(--pink)">dot</code> CLI tool.</p>
+        <p>Build real Polkadot projects across 5 pathways &mdash; pallets, contracts, transactions, XCM, and networks.</p>
         <div class="code-block" id="installCode"><button class="copy-btn" onclick="copyCode('installCmd')" title="Copy">&#x2398;</button><span id="installCmd"><span class="prompt">$</span> curl -fsSL https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/master/install.sh | bash</span></div>
       </div>
       <div class="step reveal">


### PR DESCRIPTION
## Summary
- Replace generic "One command to install the dot CLI tool" with copy that tells users they can build real Polkadot projects across all 5 pathways: pallets, contracts, transactions, XCM, and networks

## Test plan
- [ ] Verify quickstart Step 01 description reads: "Build real Polkadot projects across 5 pathways — pallets, contracts, transactions, XCM, and networks."