### PR TITLE
ci: notify on cancelled test runs and trigger badge refresh

### DIFF
--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -6,7 +6,7 @@ on:
       test_result:
         required: true
         type: string
-        description: 'Result of the test job (success/failure)'
+        description: 'Result of the test job (success/failure/cancelled)'
       readme_path:
         required: true
         type: string
@@ -19,7 +19,7 @@ on:
 
 jobs:
   notify-failure:
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && inputs.test_result == 'failure' && inputs.workflow_name != ''
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && (inputs.test_result == 'failure' || inputs.test_result == 'cancelled') && inputs.workflow_name != ''
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -45,7 +45,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ISSUE_TITLE="[Test Failure] ${{ inputs.workflow_name }}"
+          STATUS="${{ inputs.test_result }}"
+          if [ "$STATUS" = "cancelled" ]; then
+            ISSUE_TITLE="[Test Cancelled] ${{ inputs.workflow_name }}"
+          else
+            ISSUE_TITLE="[Test Failure] ${{ inputs.workflow_name }}"
+          fi
           EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number // empty')
           echo "existing_issue=$EXISTING_ISSUE" >> $GITHUB_OUTPUT
           echo "title=$ISSUE_TITLE" >> $GITHUB_OUTPUT
@@ -58,7 +63,7 @@ jobs:
           MAINTAINERS="${{ steps.maintainers.outputs.list }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          BODY="The **${{ inputs.workflow_name }}** guide test is failing on master.
+          BODY="The **${{ inputs.workflow_name }}** guide test is **${{ inputs.test_result }}** on master.
 
           **Details:**
           - Guide: \`${{ steps.guide.outputs.path }}\`

--- a/polkadot-docs/parachains/set-up-parachain-template/vitest.config.ts
+++ b/polkadot-docs/parachains/set-up-parachain-template/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+
 import { loadVariables } from "../../shared/load-variables";
 
 const vars = loadVariables();


### PR DESCRIPTION
## Summary
- Extend `post-cleanup.yml` notification to also fire on `cancelled` test results (not just `failure`)
- Creates issues with `[Test Cancelled]` title to distinguish from `[Test Failure]`
- Includes a trivial whitespace change to `set-up-parachain-template/vitest.config.ts` to trigger a push-event workflow run on merge, refreshing the badge on docs.polkadot.com

## Test plan
- [ ] After merge, verify the `Set Up Parachain Template` workflow triggers and the badge turns green