### PR TITLE
fix: update Cargo.lock for v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "cliclack",


### PR DESCRIPTION
## Summary
- The release PR bumped Cargo.toml to v0.11.1 but didn't regenerate Cargo.lock
- CI builds fail with `--locked` because the lock file still references v0.11.0
- Uses `cargo update --workspace` to only bump workspace crate versions without updating external deps

## Test plan
- [ ] CI passes with `--locked` builds
- [ ] Publish Release workflow succeeds