### PR TITLE
fix: update Cargo.lock in release workflow after version bump

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -341,6 +341,9 @@ jobs:
           # Update workspace version in root Cargo.toml
           sed -i "s/^version = \".*\"/version = \"$CARGO_VERSION\"/" Cargo.toml
 
+          # Update Cargo.lock to reflect the new version
+          cargo update --workspace
+
           echo "Updated Cargo.toml workspace version to $CARGO_VERSION"
 
       - name: Create release branch and PR
@@ -358,7 +361,7 @@ jobs:
           git checkout -b $BRANCH_NAME
 
           # Commit release files and updated Cargo.toml
-          git add .github/releases/$NEW_VERSION/ Cargo.toml
+          git add .github/releases/$NEW_VERSION/ Cargo.toml Cargo.lock
           git commit -m "chore(release): add manifest and notes for $NEW_VERSION"
 
           # Push branch


### PR DESCRIPTION
## Summary
- The release workflow bumps the version in `Cargo.toml` but wasn't updating `Cargo.lock`
- This caused all `--locked` builds to fail after merging the release PR (as seen with v0.11.1)
- Adds `cargo update --workspace` after the version bump and includes `Cargo.lock` in the release commit

## Test plan
- [ ] Next release PR should include an updated `Cargo.lock`
- [ ] CI builds with `--locked` should pass after merging a release PR