### PR TITLE
fix: re-trigger publish release for v0.11.1

### DIFF
--- a/.github/releases/v0.11.1/manifest.yml
+++ b/.github/releases/v0.11.1/manifest.yml
@@ -1,5 +1,5 @@
 release: v0.11.1
-release_date: 2026-02-18T04:15:49Z
+release_date: "2026-02-18T04:15:49Z"
 status: alpha
 
 tooling:


### PR DESCRIPTION
Trivial manifest change to re-trigger the publish-release workflow now that Cargo.lock is fixed.