### PR TITLE
fix(ci): handle unsearchable authors in PR guidance workflow

### DIFF
--- a/.github/workflows/pr-recipe-guidance.yml
+++ b/.github/workflows/pr-recipe-guidance.yml
@@ -22,14 +22,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const author = context.payload.pull_request.user.login;
-            const { data } = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${author}`,
-              per_page: 1,
-            });
-            if (data.total_count > 0) {
-              core.info(`Skipping: ${author} has ${data.total_count} previously merged PR(s)`);
-              core.setOutput('found', 'false');
-              return;
+            try {
+              const { data } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged author:${author}`,
+                per_page: 1,
+              });
+              if (data.total_count > 0) {
+                core.info(`Skipping: ${author} has ${data.total_count} previously merged PR(s)`);
+                core.setOutput('found', 'false');
+                return;
+              }
+            } catch (err) {
+              core.warning(`Could not search PRs for author ${author}: ${err.message}. Treating as new contributor.`);
             }
 
             const files = await github.paginate(github.rest.pulls.listFiles, {


### PR DESCRIPTION
## Summary
- The `guidance-comment` job in `pr-recipe-guidance.yml` crashes with a 422 when the PR author's GitHub account can't be searched (deleted, renamed, or restricted privacy settings)
- Wraps the `search.issuesAndPullRequests` call in a try/catch so the workflow treats unsearchable authors as new contributors instead of failing the entire job

## Test plan
- [x] Verify the fix applies cleanly to the workflow file
- [ ] Re-run the failed CI job on PR #170 after merge to confirm it passes