### PR TITLE
fix(ci): update sync script for renamed chain_spec_builder key

### DIFF
--- a/.github/scripts/sync-versions.sh
+++ b/.github/scripts/sync-versions.sh
@@ -95,7 +95,7 @@ check_and_update \
 check_and_update \
   "Chain Spec Builder" \
   ".parachain_template.crates.chain_spec_builder.version" \
-  ".dependencies.repositories.polkadot_sdk_parachain_template.subdependencies.chain_spec_builder_version"
+  ".dependencies.repositories.polkadot_sdk_parachain_template.subdependencies.staging_chain_spec_builder_version"
 
 check_and_update \
   "Zombienet" \


### PR DESCRIPTION
## Summary
- Upstream polkadot-docs PR #1519 renames the YAML key `chain_spec_builder_version` to `staging_chain_spec_builder_version` in `variables.yml`
- Without this fix, the weekly version sync would silently skip chain-spec-builder updates (yq path returns `null`)

## Test plan
- [ ] Verify sync script picks up the new key after upstream PR merges