### PR TITLE
fix(ci): add libclang-dev to integration test workflow

### DIFF
--- a/.github/workflows/test-pathway-integration.yml
+++ b/.github/workflows/test-pathway-integration.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Add CLI to PATH
         run: echo "${{ github.workspace }}/target/release" >> $GITHUB_PATH
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libclang-dev
 
       - name: Cache polkadot tools
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- The scheduled integration test run fails when the polkadot-tools cache misses because `cargo install polkadot-omni-node` builds `clang-sys` from source, which requires `libclang`
- Adds `libclang-dev` to the apt install step alongside `protobuf-compiler`

## Test plan
- [ ] Re-run the scheduled integration workflow after merge to confirm it passes