### PR TITLE
fix: run REVM migration tests against pallet-revive dev node

### DIFF
--- a/.github/workflows/migration-revm-uniswap-v2-periphery.yml
+++ b/.github/workflows/migration-revm-uniswap-v2-periphery.yml
@@ -5,9 +5,11 @@ on:
     branches: [master]
     paths:
       - 'migration/revm/uniswap-v2-periphery/**'
+      - 'versions.yml'
   pull_request:
     paths:
       - 'migration/revm/uniswap-v2-periphery/**'
+      - 'versions.yml'
   workflow_dispatch:
 
 jobs:
@@ -18,9 +20,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Setup pallet-revive dev node
+        uses: ./.github/actions/setup-revive-dev-node
+        with:
+          polkadot-sdk-version: ${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
       - name: Install npm dependencies
         run: |

--- a/migration/revm/uniswap-v2-core/tests/guide.test.ts
+++ b/migration/revm/uniswap-v2-core/tests/guide.test.ts
@@ -98,7 +98,7 @@ describe("Uniswap V2 Core REVM Migration", () => {
     it("should run tests on pallet-revive dev node", () => {
       console.log("Running tests on pallet-revive dev node...");
 
-      execSync("npx hardhat test --network localhost", {
+      execSync("npx hardhat test --network local", {
         cwd: WORKSPACE_DIR,
         encoding: "utf-8",
         stdio: "inherit",

--- a/migration/revm/uniswap-v2-periphery/tests/guide.test.ts
+++ b/migration/revm/uniswap-v2-periphery/tests/guide.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execSync } from "child_process";
-import { existsSync, rmSync } from "fs";
+import { existsSync, rmSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
@@ -53,6 +53,13 @@ describe("Uniswap V2 Periphery REVM Migration", () => {
 
       expect(existsSync(join(WORKSPACE_DIR, "package.json"))).toBe(true);
       expect(existsSync(join(WORKSPACE_DIR, "hardhat.config.ts"))).toBe(true);
+
+      // Patch local network URL: eth-rpc binds to IPv6 [::1]:8545,
+      // so 127.0.0.1 (IPv4) won't reach it — use localhost instead
+      const configPath = join(WORKSPACE_DIR, "hardhat.config.ts");
+      const config = readFileSync(configPath, "utf-8");
+      writeFileSync(configPath, config.replace("http://127.0.0.1:8545", "http://localhost:8545"));
+
       console.log("Repository cloned successfully");
     }, 120000);
 
@@ -96,17 +103,17 @@ describe("Uniswap V2 Periphery REVM Migration", () => {
       console.log("Contracts compiled successfully");
     }, 300000);
 
-    it("should run tests on hardhat network", () => {
-      console.log("Running tests on hardhat network...");
+    it("should run tests on pallet-revive dev node", () => {
+      console.log("Running tests on pallet-revive dev node...");
 
-      execSync("npx hardhat test", {
+      execSync("npx hardhat test --network local", {
         cwd: WORKSPACE_DIR,
         encoding: "utf-8",
         stdio: "inherit",
         timeout: 600000,
       });
 
-      console.log("Tests completed successfully on hardhat network");
+      console.log("Tests completed successfully on pallet-revive dev node");
     }, 900000);
   });
 });


### PR DESCRIPTION
## Summary

Both REVM migration tests were not properly running against the pallet-revive dev node:

- **uniswap-v2-core**: Used `--network localhost` (Hardhat's built-in network config) instead of `--network local` (the upstream repo's config with correct accounts and chainId)
- **uniswap-v2-periphery**: Had no dev node setup at all — ran entirely on Hardhat's in-memory network. Now sets up `revive-dev-node` via CI action and runs with `--network local`

## Verified locally

- uniswap-v2-core: 8/8 tests pass against dev node
- uniswap-v2-periphery: 8/8 tests pass against dev node (with localhost patch)

## Test plan

- [x] CI passes for `migration-revm-uniswap-v2-core` workflow
- [x] CI passes for `migration-revm-uniswap-v2-periphery` workflow