### PR TITLE
fix: remove unnecessary localhost patch from periphery test

### DIFF
--- a/migration/revm/uniswap-v2-periphery/tests/guide.test.ts
+++ b/migration/revm/uniswap-v2-periphery/tests/guide.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execSync } from "child_process";
-import { existsSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
@@ -53,12 +53,6 @@ describe("Uniswap V2 Periphery REVM Migration", () => {
 
       expect(existsSync(join(WORKSPACE_DIR, "package.json"))).toBe(true);
       expect(existsSync(join(WORKSPACE_DIR, "hardhat.config.ts"))).toBe(true);
-
-      // Patch local network URL: eth-rpc binds to IPv6 [::1]:8545,
-      // so 127.0.0.1 (IPv4) won't reach it — use localhost instead
-      const configPath = join(WORKSPACE_DIR, "hardhat.config.ts");
-      const config = readFileSync(configPath, "utf-8");
-      writeFileSync(configPath, config.replace("http://127.0.0.1:8545", "http://localhost:8545"));
 
       console.log("Repository cloned successfully");
     }, 120000);


### PR DESCRIPTION
## Summary

Removes the runtime patch that replaced `http://127.0.0.1:8545` with `http://localhost:8545` in the cloned upstream hardhat config during the periphery migration test.

The patch was based on the incorrect assumption that `eth-rpc --dev` only binds to IPv6 `[::1]:8545`. In reality, it binds to **both** IPv4 and IPv6:

```
Running JSON-RPC server: addr=127.0.0.1:8545,[::1]:8545
```

### Evidence

- **Local testing**: `eth_getBalance` returns identical results via `127.0.0.1`, `[::1]`, and `localhost`
- **eth-rpc logs**: explicitly shows `addr=127.0.0.1:8545,[::1]:8545`
- **polkadot-sdk#3488**: dual-stack binding was resolved in August 2024
- **Original CI failure**: was caused by the missing `setup-revive-dev-node` step, not IPv4/IPv6 — the error was `ECONNREFUSED` because nothing was listening on 8545

## Test plan

- [ ] CI passes for `migration-revm-uniswap-v2-periphery` workflow without the localhost patch