### PR TITLE
feat: add custom skills for common workflows

### DIFF
--- a/.claude/skills/add-polkadot-docs-recipe/SKILL.md
+++ b/.claude/skills/add-polkadot-docs-recipe/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: add-polkadot-docs-recipe
+description: Create a new polkadot-docs test harness that verifies a Polkadot documentation guide. Use when adding a new test for a docs.polkadot.com guide.
+argument-hint: "[guide-url]"
+---
+
+# Add Polkadot Docs Test Harness
+
+Create a test harness under `polkadot-docs/{category}/{guide-name}/` that verifies a docs.polkadot.com guide works as documented.
+
+## Step 1: Scaffold the directory
+
+Create these files in `polkadot-docs/{category}/{guide-name}/`:
+
+**package.json:**
+```json
+{
+  "name": "{guide-name}",
+  "version": "1.0.0",
+  "description": "Test verification for the {Guide Title} guide",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.9"
+  }
+}
+```
+
+**tsconfig.json:**
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+**vitest.config.ts:**
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    sequence: { shuffle: false },
+    testTimeout: 30000,      // Adjust: 30s simple, 360000 contracts, 1800000 builds
+    hookTimeout: 10000,
+    reporters: ["verbose"],
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+    include: ["tests/recipe.test.ts"],
+  },
+});
+```
+
+If the test needs pinned versions from `versions.yml`, import the shared loader:
+```typescript
+import { loadVariables } from "../../shared/load-variables";
+const vars = loadVariables();
+
+export default defineConfig({
+  test: {
+    env: {
+      POLKADOT_SDK_VERSION: vars.POLKADOT_SDK_VERSION,
+      // ... other vars as needed
+    },
+    // ... rest of config
+  },
+});
+```
+
+**.gitignore:**
+```
+node_modules/
+.test-workspace/
+dist/
+*.log
+```
+
+**README.md** — use this frontmatter format:
+```markdown
+---
+title: "{Guide Title}"
+description: "Verify the {Guide Title} guide from docs.polkadot.com"
+source_url: "https://docs.polkadot.com/{path/to/guide}/"
+source_github: "https://github.com/polkadot-developers/polkadot-docs/blob/master/{path/to/guide}.md"
+docs_commit: "{latest commit SHA from upstream}"
+---
+
+# {Guide Title}
+
+[![{Guide Title}](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-{guide-name}.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-{guide-name}.yml)
+
+This project verifies the [{Guide Title}]({source_url}) guide from docs.polkadot.com.
+
+## Running Tests
+
+\```bash
+npm ci
+npm test
+\```
+```
+
+## Step 2: Write the test
+
+Create `tests/recipe.test.ts` with numbered phases:
+
+```typescript
+import { describe, it, expect } from "vitest";
+
+describe("{Guide Title}", () => {
+  describe("1. Prerequisites", () => {
+    // Check required tools
+  });
+
+  describe("2. Setup", () => {
+    // Clone repo or set up environment
+  });
+
+  describe("3. Verify", () => {
+    // Run the guide's steps and assert correctness
+  });
+});
+```
+
+**Pinning strategy:** polkadot-docs tests pin external repos by **commit SHA** (not tags).
+
+**Cloning pattern** for tests that clone repos:
+```typescript
+const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
+const REPO_URL = "https://github.com/...";
+const PINNED_COMMIT = "abc123...";
+```
+
+## Step 3: Create the CI workflow
+
+Create `.github/workflows/polkadot-docs-{guide-name}.yml`:
+
+```yaml
+name: {Readable Guide Name}
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'polkadot-docs/{category}/{guide-name}/**'
+      - '!polkadot-docs/{category}/{guide-name}/README.md'
+      - 'versions.yml'
+  pull_request:
+    paths:
+      - 'polkadot-docs/{category}/{guide-name}/**'
+      - '!polkadot-docs/{category}/{guide-name}/README.md'
+      - 'versions.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install npm dependencies
+        run: |
+          cd polkadot-docs/{category}/{guide-name}
+          npm ci
+
+      - name: Run tests
+        run: |
+          cd polkadot-docs/{category}/{guide-name}
+          npm test
+        timeout-minutes: 10
+
+  post-test:
+    needs: test
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    uses: ./.github/workflows/post-cleanup.yml
+    with:
+      test_result: ${{ needs.test.result }}
+      readme_path: 'polkadot-docs/{category}/{guide-name}/README.md'
+      workflow_name: '{Readable Guide Name}'
+    permissions:
+      contents: read
+      issues: write
+```
+
+**CI setup for smart contract guides:**
+- **Standard contracts** (no custom precompiles): add `setup-revive-dev-node` action — runs a vanilla pallet-revive dev node + eth-rpc adapter
+- **Contracts with custom precompiles**: add `setup-zombienet-eth-rpc` action — requires a full network with a custom runtime that includes the precompile
+
+## Step 4: Run locally and generate lock file
+
+```bash
+cd polkadot-docs/{category}/{guide-name}
+npm install   # generates package-lock.json (commit this)
+npm test
+```
+
+## Step 5: Open companion PR
+
+After the cookbook PR is merged, open a **companion PR** in [`polkadot-developers/polkadot-docs`](https://github.com/polkadot-developers/polkadot-docs) to add CI badges to the documentation page. Add badges at both top and bottom of the guide:
+
+```markdown
+[![{Guide Title}](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-{guide-name}.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-{guide-name}.yml)
+```
+
+Reference the cookbook PR in the companion PR body: `Companion to polkadot-developers/polkadot-cookbook#{PR-number}`

--- a/.claude/skills/add-recipe/SKILL.md
+++ b/.claude/skills/add-recipe/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: add-recipe
+description: Create a new recipe test harness that verifies an external recipe repository. Use when adding a new recipe to the cookbook.
+argument-hint: "[recipe-name]"
+---
+
+# Add Recipe Test Harness
+
+Create a test harness under `recipes/{pathway}/{recipe-name}/` that clones an external repo, builds it, and runs its tests.
+
+Recipe source code lives in **external repos** (e.g., `brunopgalvao/recipe-{name}`). This repo only contains the test harness.
+
+## Step 1: Scaffold the directory
+
+Create these files in `recipes/{pathway}/{recipe-name}/`:
+
+**package.json:**
+```json
+{
+  "name": "{recipe-name}-test",
+  "version": "1.0.0",
+  "description": "Verification tests for the {recipe-name} recipe",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.9"
+  }
+}
+```
+
+**tsconfig.json:**
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+**vitest.config.ts:**
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    sequence: { shuffle: false },
+    testTimeout: 300000,     // 5 min for Node.js recipes, 2700000 (45 min) for Rust
+    hookTimeout: 60000,
+    reporters: ["verbose"],
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+    include: ["tests/recipe.test.ts"],
+  },
+});
+```
+
+**.gitignore:**
+```
+node_modules/
+recipe-{name}/
+dist/
+*.log
+```
+
+**README.md:**
+```markdown
+# {Recipe Title}
+
+[![{Recipe Title}](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/recipe-{recipe-name}.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/recipe-{recipe-name}.yml)
+
+[{Recipe Title}](https://github.com/brunopgalvao/recipe-{recipe-name})
+
+## Running Tests
+
+\```bash
+npm ci
+npm test
+\```
+```
+
+## Step 2: Write the test
+
+Create `tests/recipe.test.ts` with this lifecycle:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+const REPO_URL = "https://github.com/brunopgalvao/recipe-{recipe-name}";
+const REPO_VERSION = "v1.0.0";  // Must be a git tag
+const CLONE_DIR = join(process.cwd(), "recipe-{recipe-name}");
+
+describe("{Recipe Title}", () => {
+  describe("1. Prerequisites", () => {
+    it("should have required tools", () => {
+      // Check node/npm, git, cargo, etc.
+      execSync("node --version", { encoding: "utf-8" });
+      execSync("git --version", { encoding: "utf-8" });
+    });
+  });
+
+  describe("2. Clone Repository", () => {
+    it("should clone at pinned version", () => {
+      if (!existsSync(CLONE_DIR)) {
+        execSync(`git clone --branch ${REPO_VERSION} --depth 1 ${REPO_URL} ${CLONE_DIR}`, {
+          encoding: "utf-8",
+          stdio: "inherit",
+        });
+      }
+      expect(existsSync(join(CLONE_DIR, "package.json"))).toBe(true);
+    }, 120000);
+  });
+
+  describe("3. Install Dependencies", () => {
+    it("should install", () => {
+      execSync("npm ci", { cwd: CLONE_DIR, encoding: "utf-8", stdio: "inherit" });
+    });
+  });
+
+  describe("4. Build", () => {
+    it("should compile", () => {
+      // e.g., execSync("npx hardhat compile", { cwd: CLONE_DIR, ... });
+    });
+  });
+
+  describe("5. Test", () => {
+    it("should pass tests", () => {
+      // e.g., execSync("npx hardhat test", { cwd: CLONE_DIR, ... });
+    });
+  });
+});
+```
+
+**Pinning strategy:** Recipe tests pin external repos by **git tag** (e.g., `v1.0.0`).
+
+**Timeouts:** Node.js recipes ~5 min, Rust recipes ~45 min.
+
+## Step 3: Create the CI workflow
+
+Create `.github/workflows/recipe-{recipe-name}.yml`:
+
+```yaml
+name: {Readable Recipe Name}
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'recipes/{pathway}/{recipe-name}/**'
+  pull_request:
+    paths:
+      - 'recipes/{pathway}/{recipe-name}/**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install npm dependencies
+        run: |
+          cd recipes/{pathway}/{recipe-name}
+          npm ci
+
+      - name: Run tests
+        run: |
+          cd recipes/{pathway}/{recipe-name}
+          npm test
+        timeout-minutes: 15
+```
+
+Add `versions.yml` to path triggers if the recipe depends on pinned versions.
+
+**CI setup for smart contract recipes:**
+- **Standard contracts** (no custom precompiles): use `setup-revive-dev-node` action — runs a vanilla pallet-revive dev node + eth-rpc adapter
+- **Contracts with custom precompiles**: use `setup-zombienet-eth-rpc` action — requires a full network with a custom runtime that includes the precompile
+
+For Rust recipes, add Rust toolchain setup and cargo caching.
+
+## Step 4: Run locally and generate lock file
+
+```bash
+cd recipes/{pathway}/{recipe-name}
+npm install   # generates package-lock.json (commit this)
+npm test
+```
+
+## Pathways
+
+Place the recipe in the correct pathway directory:
+- `recipes/pallets/` — FRAME pallet development (Rust)
+- `recipes/contracts/` — Solidity smart contracts (Hardhat)
+- `recipes/transactions/` — Chain interactions (PAPI, TypeScript)
+- `recipes/cross-chain-transactions/` — XCM messaging (Chopsticks)
+- `recipes/networks/` — Network testing (Zombienet, Chopsticks)


### PR DESCRIPTION
## Summary
Add two custom slash command skills (`.claude/skills/`) for common development workflows:

- **`/add-polkadot-docs-recipe`** — Scaffold a polkadot-docs test harness with CI workflow, including reminder to open companion PR in polkadot-docs repo for CI badge
- **`/add-recipe`** — Scaffold a recipe test harness with CI workflow, pathway guide, and pinning conventions

Skills are loaded on-demand (not every session like CLAUDE.md), keeping context lean while providing detailed guidance when needed.

## Usage

```
❯ /add-recipe

● The /add-recipe skill is loaded. What recipe would you like to add? I need:

  1. Recipe name (e.g., contracts-example)
  2. Pathway (pallets, contracts, transactions, cross-chain-transactions, or networks)
  3. External repo URL and git tag to pin
  4. Build/test commands for the recipe
```

```
❯ /add-polkadot-docs-recipe

● The /add-polkadot-docs-recipe skill is loaded. What guide would you like to add? I need:

  1. Guide URL from docs.polkadot.com
  2. Category (chain-interactions, smart-contracts, parachains, or networks)
  3. Guide name (kebab-case, e.g., create-account)
  4. Whether it needs a dev node (revive-dev-node or zombienet-eth-rpc)
```

## Test plan
- [x] Invoke each skill and verify templates are accurate
- [ ] Compare generated scaffolds against existing harnesses