### PR TITLE
feat: use Paseo local chain spec for parachain network test

### DIFF
--- a/polkadot-docs/networks/run-a-parachain-network/.gitignore
+++ b/polkadot-docs/networks/run-a-parachain-network/.gitignore
@@ -18,3 +18,6 @@ zombienet.log
 
 # Zombienet artifacts
 *.pid
+
+# Generated chain specs
+configs/paseo-local.json

--- a/polkadot-docs/networks/run-a-parachain-network/README.md
+++ b/polkadot-docs/networks/run-a-parachain-network/README.md
@@ -17,9 +17,10 @@ This folder contains verification tests for the [Run a Parachain Network](https:
 1. **Prerequisites**: Rust, cargo, and Zombienet are available
 2. **Clone Repository**: Parity's polkadot-sdk-parachain-template is cloned
 3. **Build Parachain Binary**: `cargo build --release` succeeds
-4. **Download Relay Chain**: Polkadot binary is downloaded via `zombienet setup`
-5. **Spawn Network**: Zombienet spawns a network with relay chain and parachain
-6. **Block Production**: Both relay chain and parachain produce blocks
+4. **Download Relay Chain**: Polkadot binary is downloaded from polkadot-sdk releases
+5. **Generate Paseo Local Chain Spec**: Uses `chain-spec-builder` with the Paseo runtime to generate a local testnet chain spec with dev accounts (alice, bob)
+6. **Spawn Network**: Zombienet spawns a network with relay chain and parachain
+7. **Block Production**: Both relay chain and parachain produce blocks
 
 ## Running Tests
 
@@ -43,12 +44,13 @@ This test suite takes approximately 30-45 minutes due to:
 - Cloning the repository (~1 min)
 - Building the parachain binary (~15-30 min)
 - Downloading relay chain binary (~2-5 min)
+- Generating Paseo local chain spec (~1 min)
 - Spawning network and verifying blocks (~2-5 min)
 
 ## Network Configuration
 
 The test uses `configs/network.toml` which defines:
-- A Paseo relay chain with 2 validators (alice, bob)
+- A Paseo local relay chain with 2 validators (alice, bob) via a generated chain spec
 - A parachain (id 1000) with 1 collator
 
 ## Source Documentation

--- a/polkadot-docs/networks/run-a-parachain-network/configs/network.toml
+++ b/polkadot-docs/networks/run-a-parachain-network/configs/network.toml
@@ -3,7 +3,7 @@ timeout = 1000
 provider = "native"
 
 [relaychain]
-chain = "paseo"
+chain_spec_path = "./configs/paseo-local.json"
 default_command = "./bin/polkadot"
 
 [[relaychain.nodes]]

--- a/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts
+++ b/polkadot-docs/networks/run-a-parachain-network/tests/guide.test.ts
@@ -13,6 +13,11 @@ const POLKADOT_RELEASE_URL = `https://github.com/paritytech/polkadot-sdk/release
 const POLKADOT_BINARY = join(BIN_DIR, "polkadot");
 const POLKADOT_PREPARE_WORKER = join(BIN_DIR, "polkadot-prepare-worker");
 const POLKADOT_EXECUTE_WORKER = join(BIN_DIR, "polkadot-execute-worker");
+const CHAIN_SPEC_BUILDER = join(BIN_DIR, "chain-spec-builder");
+const CHAIN_SPEC_BUILDER_VERSION = process.env.CHAIN_SPEC_BUILDER_VERSION!;
+const PASEO_RUNTIME_VERSION = process.env.PASEO_RUNTIME_VERSION!;
+const PASEO_RUNTIME_WASM = join(BIN_DIR, "paseo_runtime.compressed.wasm");
+const PASEO_LOCAL_CHAIN_SPEC = join(PROJECT_DIR, "configs", "paseo-local.json");
 const PARACHAIN_BINARY = join(TEMPLATE_DIR, "target/release/parachain-template-node");
 const PID_FILE = join(PROJECT_DIR, "zombienet.pid");
 
@@ -180,8 +185,79 @@ describe("Run a Parachain Network Guide", () => {
     }, 300000);
   });
 
+  // ==================== GENERATE PASEO LOCAL CHAIN SPEC ====================
+  describe("4. Generate Paseo Local Chain Spec", () => {
+    it("should download chain-spec-builder", () => {
+      if (existsSync(CHAIN_SPEC_BUILDER)) {
+        console.log("chain-spec-builder already exists");
+        return;
+      }
+
+      console.log(`Downloading chain-spec-builder v${CHAIN_SPEC_BUILDER_VERSION}...`);
+
+      const platform = process.platform;
+      if (platform !== "linux") {
+        // Install via cargo for non-Linux platforms
+        execSync(
+          `cargo install staging-chain-spec-builder@${CHAIN_SPEC_BUILDER_VERSION} --locked --root ${BIN_DIR}`,
+          { encoding: "utf-8", stdio: "inherit", timeout: 600000 }
+        );
+        // cargo install puts binary in bin/bin/chain-spec-builder
+        const cargoInstallPath = join(BIN_DIR, "bin", "chain-spec-builder");
+        if (existsSync(cargoInstallPath) && !existsSync(CHAIN_SPEC_BUILDER)) {
+          execSync(`mv ${cargoInstallPath} ${CHAIN_SPEC_BUILDER}`);
+        }
+      } else {
+        execSync(
+          `curl -L -o chain-spec-builder ${POLKADOT_RELEASE_URL}/chain-spec-builder`,
+          { cwd: BIN_DIR, encoding: "utf-8", stdio: "inherit", timeout: 300000 }
+        );
+        execSync(`chmod +x chain-spec-builder`, { cwd: BIN_DIR });
+      }
+
+      expect(existsSync(CHAIN_SPEC_BUILDER)).toBe(true);
+      console.log("chain-spec-builder downloaded successfully");
+    }, 600000);
+
+    it("should download Paseo runtime WASM", () => {
+      if (existsSync(PASEO_RUNTIME_WASM)) {
+        console.log("Paseo runtime WASM already exists");
+        return;
+      }
+
+      console.log(`Downloading Paseo runtime ${PASEO_RUNTIME_VERSION}...`);
+      const releaseUrl = `https://github.com/paseo-network/runtimes/releases/download/${PASEO_RUNTIME_VERSION}/paseo_runtime.compressed.wasm`;
+      execSync(
+        `curl -L -o paseo_runtime.compressed.wasm ${releaseUrl}`,
+        { cwd: BIN_DIR, encoding: "utf-8", stdio: "inherit", timeout: 300000 }
+      );
+
+      expect(existsSync(PASEO_RUNTIME_WASM)).toBe(true);
+      console.log("Paseo runtime WASM downloaded successfully");
+    }, 300000);
+
+    it("should generate Paseo local testnet chain spec", () => {
+      if (existsSync(PASEO_LOCAL_CHAIN_SPEC)) {
+        console.log("Paseo local chain spec already exists");
+        return;
+      }
+
+      console.log("Generating Paseo local testnet chain spec...");
+
+      // Generate plain chain spec with local_testnet preset (alice + bob as validators)
+      // Zombienet expects the plain version so it can customize and convert to raw itself
+      execSync(
+        `${CHAIN_SPEC_BUILDER} -c ${PASEO_LOCAL_CHAIN_SPEC} create -r ${PASEO_RUNTIME_WASM} named-preset local_testnet`,
+        { encoding: "utf-8", stdio: "inherit" }
+      );
+
+      expect(existsSync(PASEO_LOCAL_CHAIN_SPEC)).toBe(true);
+      console.log("Paseo local chain spec generated successfully");
+    }, 60000);
+  });
+
   // ==================== CONFIGURE NETWORK ====================
-  describe("4. Configure Network", () => {
+  describe("5. Configure Network", () => {
     it("should have valid network.toml configuration", () => {
       const configPath = join(PROJECT_DIR, "configs", "network.toml");
       expect(existsSync(configPath)).toBe(true);
@@ -190,7 +266,7 @@ describe("Run a Parachain Network Guide", () => {
 
       // Verify essential configuration elements
       expect(config).toContain("[relaychain]");
-      expect(config).toContain('chain = "paseo"');
+      expect(config).toContain('chain_spec_path = "./configs/paseo-local.json"');
       expect(config).toContain("[[relaychain.nodes]]");
       expect(config).toContain('name = "alice"');
       expect(config).toContain("[[parachains]]");
@@ -201,7 +277,7 @@ describe("Run a Parachain Network Guide", () => {
   });
 
   // ==================== SPAWN NETWORK ====================
-  describe("5. Spawn Network", () => {
+  describe("6. Spawn Network", () => {
     it("should spawn the network with zombienet", async () => {
       console.log("Spawning network with Zombienet...");
 

--- a/polkadot-docs/networks/run-a-parachain-network/vitest.config.ts
+++ b/polkadot-docs/networks/run-a-parachain-network/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     env: {
       TEMPLATE_VERSION: vars.TEMPLATE_VERSION,
       POLKADOT_SDK_VERSION: vars.POLKADOT_SDK_VERSION,
+      CHAIN_SPEC_BUILDER_VERSION: vars.CHAIN_SPEC_BUILDER_VERSION,
+      PASEO_RUNTIME_VERSION: vars.PASEO_RUNTIME_VERSION,
     },
     // Run test FILES sequentially (critical - build depends on clone, spawn depends on build)
     fileParallelism: false,

--- a/polkadot-docs/shared/load-variables.ts
+++ b/polkadot-docs/shared/load-variables.ts
@@ -8,6 +8,7 @@ export interface Variables {
   ZOMBIENET_VERSION: string;
   POLKADOT_OMNI_NODE_VERSION: string;
   CHAIN_SPEC_BUILDER_VERSION: string;
+  PASEO_RUNTIME_VERSION: string;
 }
 
 interface YamlNode {
@@ -90,11 +91,15 @@ export function loadVariables(): Variables {
   const chainSpecVersion = getNestedValue(yaml, "parachain_template.crates.chain_spec_builder.version");
   if (!chainSpecVersion) throw new Error("Missing parachain_template.crates.chain_spec_builder.version in versions.yml");
 
+  const paseoRuntimeVersion = getNestedValue(yaml, "paseo_runtime.version");
+  if (!paseoRuntimeVersion) throw new Error("Missing paseo_runtime.version in versions.yml");
+
   return {
     TEMPLATE_VERSION: templateVersion,
     POLKADOT_SDK_VERSION: sdkVersion,
     ZOMBIENET_VERSION: zombienetVersion,
     POLKADOT_OMNI_NODE_VERSION: omniNodeVersion,
     CHAIN_SPEC_BUILDER_VERSION: chainSpecVersion,
+    PASEO_RUNTIME_VERSION: paseoRuntimeVersion,
   };
 }

--- a/versions.yml
+++ b/versions.yml
@@ -25,6 +25,10 @@ parachain_template:
       name: staging-chain-spec-builder
       version: "16.0.0"
 
+paseo_runtime:
+  version: v1.9.2
+  repository: https://github.com/paseo-network/runtimes
+
 zombienet:
   version: v1.3.138
   repository: https://github.com/paritytech/zombienet


### PR DESCRIPTION
## Summary

- Replaces `chain = "paseo"` (which loaded the live Paseo testnet genesis and couldn't produce blocks locally) with a generated Paseo local chain spec
- Uses `chain-spec-builder` with the Paseo runtime's `local_testnet` preset to generate a chain spec with dev accounts (alice, bob) as validators
- Adds `paseo_runtime` version (`v1.9.2`) to `versions.yml`

## How It Works

1. Downloads `chain-spec-builder` from polkadot-sdk releases
2. Downloads `paseo_runtime.compressed.wasm` from `paseo-network/runtimes` releases
3. Generates a plain chain spec via `chain-spec-builder create -r paseo_runtime.wasm named-preset local_testnet`
4. Zombienet uses the generated spec via `chain_spec_path` in `network.toml`

The `local_testnet` preset includes alice + bob as validators, all dev accounts endowed, and Alice as sudo.

## Test plan

- [ ] CI passes: relay chain produces blocks with the generated Paseo local chain spec
- [ ] Parachain is onboarded and produces blocks
- [ ] RPC endpoints respond correctly