### PR TITLE
feat: selective versions.yml workflow triggering with guard jobs

### DIFF
--- a/.github/actions/check-version-keys/action.yml
+++ b/.github/actions/check-version-keys/action.yml
@@ -1,0 +1,88 @@
+name: 'Check Version Keys'
+description: 'Check if specific versions.yml keys changed to decide whether a workflow should run. Keys are auto-detected from yq calls in the calling workflow file.'
+
+inputs:
+  base-sha:
+    description: 'Base commit SHA for comparison'
+    required: true
+  head-sha:
+    description: 'Head commit SHA for comparison'
+    required: true
+  event-name:
+    description: 'GitHub event name (push, pull_request, workflow_dispatch)'
+    required: true
+
+outputs:
+  should-run:
+    description: '"true" if the workflow should run, "false" if it can be skipped'
+    value: ${{ steps.check.outputs.should-run }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: check
+      shell: bash
+      run: |
+        EVENT="${{ inputs.event-name }}"
+        BASE_SHA="${{ inputs.base-sha }}"
+
+        # Always run on workflow_dispatch or if base SHA is missing
+        if [ "$EVENT" = "workflow_dispatch" ] || [ -z "$BASE_SHA" ]; then
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "Always run: event=$EVENT base_sha=$BASE_SHA"
+          exit 0
+        fi
+
+        # Check if versions.yml is in the diff
+        CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "${{ inputs.head-sha }}" 2>/dev/null || true)
+
+        if ! echo "$CHANGED_FILES" | grep -q '^versions\.yml$'; then
+          # versions.yml not changed — triggered by harness file changes, always run
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "Always run: versions.yml not in diff"
+          exit 0
+        fi
+
+        # Auto-detect keys from the calling workflow file
+        WORKFLOW_FILE=".github/workflows/$(echo "$GITHUB_WORKFLOW_REF" | sed -n 's|.*\.github/workflows/\(.*\)@.*|\1|p')"
+        echo "Detected workflow file: $WORKFLOW_FILE"
+
+        if [ ! -f "$WORKFLOW_FILE" ]; then
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "Always run: could not locate workflow file"
+          exit 0
+        fi
+
+        KEYS=$(grep -oP "yq\s+'(\.[^']+)'\s+versions\.yml" "$WORKFLOW_FILE" | grep -oP "'\.[^']+'" | tr -d "'" | sort -u | tr '\n' ' ')
+        echo "Auto-detected keys: $KEYS"
+
+        if [ -z "$KEYS" ]; then
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "Always run: no version keys detected in workflow"
+          exit 0
+        fi
+
+        # versions.yml changed — check if any of the specific keys changed
+        git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || true
+        OLD_FILE=$(git show "$BASE_SHA":versions.yml 2>/dev/null || echo "")
+
+        if [ -z "$OLD_FILE" ]; then
+          # Can't get old file (new file or shallow clone issue) — run to be safe
+          echo "should-run=true" >> "$GITHUB_OUTPUT"
+          echo "Always run: could not retrieve old versions.yml"
+          exit 0
+        fi
+
+        for KEY in $KEYS; do
+          OLD_VAL=$(echo "$OLD_FILE" | yq "$KEY" 2>/dev/null || echo "")
+          NEW_VAL=$(yq "$KEY" versions.yml 2>/dev/null || echo "")
+          if [ "$OLD_VAL" != "$NEW_VAL" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Key changed: $KEY ($OLD_VAL -> $NEW_VAL)"
+            exit 0
+          fi
+          echo "Key unchanged: $KEY ($OLD_VAL)"
+        done
+
+        echo "should-run=false" >> "$GITHUB_OUTPUT"
+        echo "No relevant keys changed, skipping"

--- a/.github/workflows/migration-revm-uniswap-v2-core.yml
+++ b/.github/workflows/migration-revm-uniswap-v2-core.yml
@@ -13,8 +13,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/migration-revm-uniswap-v2-periphery.yml
+++ b/.github/workflows/migration-revm-uniswap-v2-periphery.yml
@@ -13,8 +13,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/polkadot-docs-add-existing-pallets.yml
+++ b/.github/workflows/polkadot-docs-add-existing-pallets.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -99,8 +114,8 @@ jobs:
         timeout-minutes: 60
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-add-pallet-instances.yml
+++ b/.github/workflows/polkadot-docs-add-pallet-instances.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -100,8 +115,8 @@ jobs:
         timeout-minutes: 60
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-benchmark-pallet.yml
+++ b/.github/workflows/polkadot-docs-benchmark-pallet.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -80,8 +95,8 @@ jobs:
         timeout-minutes: 45
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-channels-between-parachains.yml
+++ b/.github/workflows/polkadot-docs-channels-between-parachains.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -127,8 +142,8 @@ jobs:
           pkill -f 'zombienet' 2>/dev/null || true
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-channels-with-system-parachains.yml
+++ b/.github/workflows/polkadot-docs-channels-with-system-parachains.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -128,8 +143,8 @@ jobs:
           pkill -f 'zombienet' 2>/dev/null || true
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-create-a-pallet.yml
+++ b/.github/workflows/polkadot-docs-create-a-pallet.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -100,8 +115,8 @@ jobs:
         timeout-minutes: 60
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-create-account.yml
+++ b/.github/workflows/polkadot-docs-create-account.yml
@@ -15,12 +15,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_JS_UTIL_CRYPTO_VERSION=$(yq '.javascript_packages.polkadot_js_util_crypto.version' versions.yml)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v4
         with:
@@ -30,6 +50,9 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/create-account
           npm ci
+          npm install --save-exact \
+            @polkadot/keyring@${{ steps.versions.outputs.POLKADOT_JS_UTIL_CRYPTO_VERSION }} \
+            @polkadot/util-crypto@${{ steps.versions.outputs.POLKADOT_JS_UTIL_CRYPTO_VERSION }}
 
       - name: Run tests
         run: |
@@ -38,8 +61,8 @@ jobs:
         timeout-minutes: 5
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
+++ b/.github/workflows/polkadot-docs-install-polkadot-sdk.yml
@@ -15,12 +15,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Load versions
+        id: versions
+        run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         run: |
@@ -59,10 +79,12 @@ jobs:
           cd polkadot-docs/parachains/install-polkadot-sdk
           npm test
         timeout-minutes: 15
+        env:
+          POLKADOT_SDK_VERSION: ${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-local-dev-node.yml
+++ b/.github/workflows/polkadot-docs-local-dev-node.yml
@@ -15,9 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    # Guard: only run in the canonical repository to protect CI secrets
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -84,10 +98,11 @@ jobs:
         timeout-minutes: 120  # cold build: ~60 min per binary; warm build: ~5 min
 
   post-test:
-    needs: test
+    needs: [guard, test]
     # Only file issues on master failures — not on every PR
     if: >
       github.repository == 'polkadot-developers/polkadot-cookbook' &&
+      needs.guard.outputs.should-run == 'true' &&
       always() &&
       github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml

--- a/.github/workflows/polkadot-docs-mock-runtime.yml
+++ b/.github/workflows/polkadot-docs-mock-runtime.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -80,8 +95,8 @@ jobs:
         timeout-minutes: 45
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-pallet-testing.yml
+++ b/.github/workflows/polkadot-docs-pallet-testing.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -80,8 +95,8 @@ jobs:
         timeout-minutes: 45
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-query-accounts.yml
+++ b/.github/workflows/polkadot-docs-query-accounts.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,8 +93,8 @@ jobs:
         timeout-minutes: 5
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-query-sdks.yml
+++ b/.github/workflows/polkadot-docs-query-sdks.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -78,8 +93,8 @@ jobs:
         timeout-minutes: 5
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -95,8 +110,8 @@ jobs:
         timeout-minutes: 60
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-runtime-upgrades.yml
+++ b/.github/workflows/polkadot-docs-runtime-upgrades.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -127,8 +142,8 @@ jobs:
           pkill -f 'zombienet' 2>/dev/null || true
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/polkadot-docs-set-up-parachain-template.yml
+++ b/.github/workflows/polkadot-docs-set-up-parachain-template.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -100,8 +115,8 @@ jobs:
         timeout-minutes: 60
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-contracts-example.yml
+++ b/.github/workflows/recipe-contracts-example.yml
@@ -13,8 +13,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -46,8 +61,8 @@ jobs:
         timeout-minutes: 15
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && always() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && always() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/.github/workflows/recipe-contracts-precompile-example.yml
+++ b/.github/workflows/recipe-contracts-precompile-example.yml
@@ -15,8 +15,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  guard:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        uses: ./.github/actions/check-version-keys
+        with:
+          event-name: ${{ github.event_name }}
+          base-sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head-sha: ${{ github.sha }}
+
+  test:
+    needs: guard
+    if: needs.guard.outputs.should-run == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -50,8 +65,8 @@ jobs:
         timeout-minutes: 15
 
   post-test:
-    needs: test
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && success() && github.ref == 'refs/heads/master'
+    needs: [guard, test]
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && needs.guard.outputs.should-run == 'true' && success() && github.ref == 'refs/heads/master'
     uses: ./.github/workflows/post-cleanup.yml
     with:
       test_result: ${{ needs.test.result }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ npm ci && npm test
 
 **`versions.yml`**: Single source of truth for pinned dependency versions (polkadot-sdk release tag, parachain template version, zombienet version). Referenced by CI workflows and `polkadot-docs/shared/load-variables.ts` (shared utility that parses versions at test runtime). Changes here trigger downstream CI runs.
 
-**CI composite actions** (`.github/actions/`): Reusable actions like `setup-revive-dev-node` (builds/caches pallet-revive dev node + eth-rpc adapter) and `setup-zombienet-eth-rpc`. Used by recipe and migration workflows.
+**CI composite actions** (`.github/actions/`): Reusable actions like `setup-revive-dev-node` (builds/caches pallet-revive dev node + eth-rpc adapter), `setup-zombienet-eth-rpc`, and `check-version-keys` (guard that skips expensive test jobs when a `versions.yml` change doesn't affect the workflow's keys). Used by recipe, migration, and polkadot-docs workflows.
 
 ## Key Conventions
 
@@ -53,7 +53,8 @@ npm ci && npm test
 - Recipe source code lives in **external repos** (`brunopgalvao/recipe-*`); this repo only contains test harnesses
 - Test file naming: recipes use `recipe.test.ts`, migrations use `guide.test.ts`
 - CI workflows are **path-filtered** per component (e.g., `recipe-contracts-example.yml` only triggers on `recipes/contracts/contracts-example/**`)
-- `versions.yml` changes also trigger downstream workflow runs
+- `versions.yml` changes also trigger downstream workflow runs — each workflow has a `guard` job that auto-detects which `versions.yml` keys it uses (by parsing `yq` calls in the workflow file) and skips the test job if none of those keys changed
+- When adding a new `yq '...' versions.yml` line to a workflow's "Load versions" step, the guard picks it up automatically — no separate key list to maintain
 - Commit both `Cargo.lock` and `package-lock.json` — locked dependencies are intentional
 - No local git hooks — run `cargo fmt` and `cargo clippy` manually before pushing
 - Workspace version: check `Cargo.toml` `[workspace.package]`

--- a/polkadot-docs/chain-interactions/create-account/package-lock.json
+++ b/polkadot-docs/chain-interactions/create-account/package-lock.json
@@ -8,8 +8,8 @@
       "name": "create-account",
       "version": "1.0.0",
       "dependencies": {
-        "@polkadot/keyring": "^13.3.1",
-        "@polkadot/util-crypto": "^13.3.1"
+        "@polkadot/keyring": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/create-account/package.json
+++ b/polkadot-docs/chain-interactions/create-account/package.json
@@ -7,8 +7,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@polkadot/keyring": "^13.3.1",
-    "@polkadot/util-crypto": "^13.3.1"
+    "@polkadot/keyring": "13.5.9",
+    "@polkadot/util-crypto": "13.5.9"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/parachains/install-polkadot-sdk/tests/guide.test.ts
+++ b/polkadot-docs/parachains/install-polkadot-sdk/tests/guide.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 
 const WORKSPACE_DIR = join(process.cwd(), ".test-workspace");
 const SDK_DIR = join(WORKSPACE_DIR, "polkadot-sdk");
+const POLKADOT_SDK_VERSION = process.env.POLKADOT_SDK_VERSION || "";
 
 describe("Install Polkadot SDK Guide", () => {
   // ==================== RUST INSTALLATION ====================
@@ -90,6 +91,10 @@ describe("Install Polkadot SDK Guide", () => {
         mkdirSync(WORKSPACE_DIR, { recursive: true });
       }
 
+      const branchFlag = POLKADOT_SDK_VERSION
+        ? `--branch ${POLKADOT_SDK_VERSION}`
+        : "";
+
       if (existsSync(SDK_DIR)) {
         console.log("polkadot-sdk already cloned, updating...");
         execSync("git fetch --depth 1", {
@@ -98,9 +103,11 @@ describe("Install Polkadot SDK Guide", () => {
           stdio: "inherit",
         });
       } else {
-        console.log("Cloning polkadot-sdk (shallow clone for speed)...");
+        console.log(
+          `Cloning polkadot-sdk (shallow clone${POLKADOT_SDK_VERSION ? ` at ${POLKADOT_SDK_VERSION}` : ""})...`
+        );
         execSync(
-          `git clone --depth 1 https://github.com/paritytech/polkadot-sdk.git ${SDK_DIR}`,
+          `git clone --depth 1 ${branchFlag} https://github.com/paritytech/polkadot-sdk.git ${SDK_DIR}`,
           { encoding: "utf-8", stdio: "inherit" }
         );
       }

--- a/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/tests/guide.test.ts
+++ b/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/tests/guide.test.ts
@@ -720,9 +720,10 @@ impl pallet_custom::Config for Runtime {
     }, 120000);
 
     it("should have spec_version = 2 after upgrade", async () => {
-      // Poll for the spec version change (may take a block or two)
+      // Poll for the spec version change — parachain block times under
+      // Zombienet can be variable, so retry generously.
       let specVersion = 0;
-      for (let attempt = 1; attempt <= 5; attempt++) {
+      for (let attempt = 1; attempt <= 10; attempt++) {
         const result = (await rpcCall("state_getRuntimeVersion")) as {
           specName: string;
           specVersion: number;
@@ -733,7 +734,7 @@ impl pallet_custom::Config for Runtime {
         await new Promise((resolve) => setTimeout(resolve, 12000));
       }
       expect(specVersion).toBe(2);
-    }, 90000);
+    }, 180000);
   });
 
   // ==================== POST-UPGRADE VERIFICATION ====================

--- a/versions.yml
+++ b/versions.yml
@@ -59,6 +59,9 @@ javascript_packages:
   dedot_chaintypes:
     name: "@dedot/chaintypes"
     version: "0.242.0"
+  polkadot_js_util_crypto:
+    name: "@polkadot/util-crypto"
+    version: "13.5.9"
 
 # Python packages
 python_packages:


### PR DESCRIPTION
## Summary

- Add a `check-version-keys` composite action that gates expensive test jobs when `versions.yml` changes
- The guard **auto-detects** which `versions.yml` keys each workflow uses by parsing `yq` calls in the workflow file — no manual key list to maintain
- Workflows only run their test job when a relevant key actually changed; unrelated `versions.yml` edits are skipped
- On `workflow_dispatch` or when `versions.yml` isn't in the diff, workflows always run (safe defaults)
- Includes fix for runtime-upgrades `spec_version` polling retries and `polkadot_js_util_crypto` version alignment

## How it works

Each of the 20 guarded workflows has a `guard` job that runs the `check-version-keys` composite action. The action:

1. Extracts the calling workflow filename from `GITHUB_WORKFLOW_REF`
2. Greps the workflow file for all `yq '<path>' versions.yml` patterns
3. Compares old vs new values for those keys only
4. Sets `should-run=true/false` — the test job gates on this output

Adding a new `yq` line to any workflow's "Load versions" step is automatically picked up by the guard on the next run — no other file needs updating.

## Test plan

- [ ] Change only `zombienet.version` in `versions.yml` — only the 5 workflows that use it should run test jobs
- [ ] `workflow_dispatch` any guarded workflow — should always run
- [ ] Push a harness-only change (no `versions.yml`) — should always run

🤖 Generated with [Claude Code](https://claude.com/claude-code)