### PR TITLE
fix: fetch base SHA before git diff in guard action

### DIFF
--- a/.github/actions/check-version-keys/action.yml
+++ b/.github/actions/check-version-keys/action.yml
@@ -33,6 +33,9 @@ runs:
           exit 0
         fi
 
+        # Fetch base SHA so git diff works in shallow clones
+        git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || true
+
         # Check if versions.yml is in the diff
         CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "${{ inputs.head-sha }}" 2>/dev/null || true)
 
@@ -63,7 +66,6 @@ runs:
         fi
 
         # versions.yml changed — check if any of the specific keys changed
-        git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || true
         OLD_FILE=$(git show "$BASE_SHA":versions.yml 2>/dev/null || echo "")
 
         if [ -z "$OLD_FILE" ]; then


### PR DESCRIPTION
## Summary

- Fix shallow clone issue in `check-version-keys` guard action where `git diff` silently failed because the base SHA wasn't available
- Move `git fetch origin $BASE_SHA` **before** the `git diff` check so the comparison can actually find changed files
- Without this fix, the guard always returned `should-run=true` on PRs, defeating the purpose of selective triggering

## Root cause

`actions/checkout@v4` does a depth-1 shallow clone by default. The base SHA (from `github.event.pull_request.base.sha`) isn't in the local history, so `git diff --name-only $BASE_SHA $HEAD_SHA` fails silently (suppressed by `|| true`), returning empty output. The guard then concludes "versions.yml not in diff" and always runs.

## Verification

Tested in PR #195 — before this fix all 20 test jobs ran; after the fix all 20 correctly skipped (only `paseo_runtime.version` was changed, which no workflow references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)