### PR TITLE
fix: use pull_request_target for semantic label workflow

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -1,12 +1,12 @@
 name: Auto-Label Semantic Version
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
   analyze-commits:
-    if: github.repository == 'polkadot-developers/polkadot-cookbook' && github.event_name == 'pull_request'
+    if: github.repository == 'polkadot-developers/polkadot-cookbook' && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Rust
@@ -75,8 +76,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // Guard: only run on pull_request events
-            if (context.eventName !== 'pull_request') {
-              console.log(`Skipping: workflow triggered by '${context.eventName}' event, not 'pull_request'`);
+            if (context.eventName !== 'pull_request_target') {
+              console.log(`Skipping: workflow triggered by '${context.eventName}' event, not 'pull_request_target'`);
               return;
             }
 


### PR DESCRIPTION
## Summary
- Switch `auto-label-semantic.yml` from `pull_request` to `pull_request_target` so the `GITHUB_TOKEN` has write permissions for fork PRs
- Explicitly checkout the PR head SHA (since `pull_request_target` defaults to the base branch)
- Fixes the `analyze-commits` "Resource not accessible by integration" failure seen on PR #194

## Test plan
- [ ] Merge this PR, then re-trigger or push to PR #194 — `analyze-commits` should succeed
- [ ] Verify labels are correctly applied on new PRs