### PR TITLE
fix: add issues write permission to semantic label workflow

### DIFF
--- a/.github/workflows/auto-label-semantic.yml
+++ b/.github/workflows/auto-label-semantic.yml
@@ -9,6 +9,7 @@ jobs:
     if: github.repository == 'polkadot-developers/polkadot-cookbook' && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
       contents: read
 


### PR DESCRIPTION
## Summary
- Add `issues: write` permission to the `analyze-commits` job
- GitHub's label API (`/issues/{id}/labels`) requires `issues: write` in addition to `pull-requests: write`
- This was the actual cause of the 403 "Resource not accessible by integration" on PR #194

## Test plan
- [ ] Merge this, then push a new commit to PR #194 to trigger `pull_request_target` — `analyze-commits` should succeed