### PR TITLE
fix: add missing badges to polkadot-docs README

### DIFF
--- a/polkadot-docs/README.md
+++ b/polkadot-docs/README.md
@@ -8,8 +8,11 @@ This repository serves as the **source of truth** that Polkadot documentation wo
 
 ## Verified Guides
 
+### Parachains
+
 | Guide | Status | Source |
 |-------|--------|--------|
+| [Install Polkadot SDK](./parachains/install-polkadot-sdk/) | [![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/install-polkadot-sdk/) |
 | [Set Up Parachain Template](./parachains/set-up-parachain-template/) | [![Set Up Parachain Template](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-set-up-parachain-template.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/launch-a-parachain/set-up-the-parachain-template/) |
 | [Add Existing Pallets](./parachains/customize-runtime/add-existing-pallets/) | [![Add Existing Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-existing-pallets.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/customize-runtime/add-existing-pallets/) |
 | [Add Pallet Instances](./parachains/customize-runtime/add-pallet-instances/) | [![Add Pallet Instances](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-add-pallet-instances.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/customize-runtime/add-pallet-instances/) |
@@ -17,9 +20,32 @@ This repository serves as the **source of truth** that Polkadot documentation wo
 | [Mock Your Runtime](./parachains/customize-runtime/pallet-development/mock-runtime/) | [![Mock Your Runtime](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-mock-runtime.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/customize-runtime/pallet-development/mock-runtime/) |
 | [Unit Test Pallets](./parachains/customize-runtime/pallet-development/pallet-testing/) | [![Unit Test Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-pallet-testing.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/customize-runtime/pallet-development/pallet-testing/) |
 | [Benchmark Pallets](./parachains/customize-runtime/pallet-development/benchmark-pallet/) | [![Benchmark Pallets](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-benchmark-pallet.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/customize-runtime/pallet-development/benchmark-pallet/) |
-| [Install Polkadot SDK](./parachains/install-polkadot-sdk/) | [![Install Polkadot SDK](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-install-polkadot-sdk.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/install-polkadot-sdk/) |
+| [Channels Between Parachains](./parachains/interoperability/channels-between-parachains/) | [![Channels Between Parachains](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-between-parachains.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-between-parachains.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/interoperability/channels-between-parachains/) |
+| [Channels with System Parachains](./parachains/interoperability/channels-with-system-parachains/) | [![Channels with System Parachains](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-with-system-parachains.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-channels-with-system-parachains.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/interoperability/channels-with-system-parachains/) |
+| [Runtime Upgrades](./parachains/runtime-maintenance/runtime-upgrades/) | [![Runtime Upgrades](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-runtime-upgrades.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-runtime-upgrades.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/runtime-maintenance/runtime-upgrades/) |
+
+### Networks
+
+| Guide | Status | Source |
+|-------|--------|--------|
 | [Run a Parachain Network](./networks/run-a-parachain-network/) | [![Run a Parachain Network](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-run-a-parachain-network.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/testing/run-a-parachain-network/) |
 | [Fork a Parachain](./parachains/testing/fork-a-parachain/) | [![Fork a Parachain](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-fork-a-parachain.yml) | [docs.polkadot.com](https://docs.polkadot.com/parachains/testing/fork-a-parachain/) |
+
+### Chain Interactions
+
+| Guide | Status | Source |
+|-------|--------|--------|
+| [Create an Account](./chain-interactions/create-account/) | [![Create an Account](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-account.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-create-account.yml) | [docs.polkadot.com](https://docs.polkadot.com/chain-interactions/accounts/create-account/) |
+| [Query Account Information](./chain-interactions/query-accounts/) | [![Query Account Information](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-accounts.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-accounts.yml) | [docs.polkadot.com](https://docs.polkadot.com/chain-interactions/accounts/query-accounts/) |
+| [Query On-Chain State with SDKs](./chain-interactions/query-sdks/) | [![Query On-Chain State with SDKs](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-sdks.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-query-sdks.yml) | [docs.polkadot.com](https://docs.polkadot.com/chain-interactions/query-data/query-sdks/) |
+
+### Smart Contracts
+
+| Guide | Status | Source |
+|-------|--------|--------|
+| [Local Development Node](./smart-contracts/local-dev-node/) | [![Local Development Node](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-local-dev-node.yml) | [docs.polkadot.com](https://docs.polkadot.com/smart-contracts/dev-environments/local-dev-node/) |
+| [Basic Contract with Hardhat](./smart-contracts/basic-hardhat/) | [![Basic Contract with Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-basic-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-basic-hardhat.yml) | [docs.polkadot.com](https://docs.polkadot.com/smart-contracts/cookbook/smart-contracts/deploy-basic/basic-hardhat/) |
+| [ERC-20 with Hardhat](./smart-contracts/erc20-hardhat/) | [![ERC-20 with Hardhat](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml/badge.svg?event=push)](https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-erc20-hardhat.yml) | [docs.polkadot.com](https://docs.polkadot.com/smart-contracts/cookbook/smart-contracts/deploy-erc20/erc20-hardhat/) |
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Add 9 missing CI badge entries to `polkadot-docs/README.md`
- Organize the table by category (Parachains, Networks, Chain Interactions, Smart Contracts)

### Added badges

- Channels Between Parachains
- Channels with System Parachains
- Runtime Upgrades
- Create an Account
- Query Account Information
- Query On-Chain State with SDKs
- Local Development Node
- Basic Contract with Hardhat
- ERC-20 with Hardhat

Total: 10 → 19 verified guides listed.

## Test plan

- [ ] Verify all badge links resolve correctly on the rendered README