### PR TITLE
chore: improve add-polkadot-docs-test skill definition

### DIFF
--- a/.claude/skills/add-polkadot-docs-test/SKILL.md
+++ b/.claude/skills/add-polkadot-docs-test/SKILL.md
@@ -573,6 +573,19 @@ After creating both PRs, update their descriptions to reference each other:
 - Cookbook PR body: add `## Companion PR\n- polkadot-developers/polkadot-docs#{companion-PR-number}`
 - Companion PR body: include `Companion to polkadot-developers/polkadot-cookbook#{cookbook-PR-number}`
 
+### 6d. Verify and Check Off Test Plan
+
+After both PRs are created, verify each test plan item and update the PR checklists:
+
+1. **CI workflow triggers correctly on PR** — run `gh pr checks {PR-number}` and confirm the test job passes
+2. **Badge renders in README** — check that the badge SVG URL returns HTTP 200:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" "https://github.com/polkadot-developers/polkadot-cookbook/actions/workflows/polkadot-docs-{guide-name}.yml/badge.svg?event=push"
+   ```
+3. **Companion PR badge** — confirm the companion PR's badge also renders after cookbook CI passes
+
+Once verified, update both PR descriptions with `gh pr edit` to check off all items (`- [x]`). Do not leave unchecked items in test plans when the checks have actually passed.
+
 ---
 
 ## Reference Files


### PR DESCRIPTION
## Summary
Improvements to the `/add-polkadot-docs-test` skill based on learnings from its first real invocation (polkadot-developers/polkadot-cookbook#210):

- **Code fidelity**: Tests must faithfully reproduce the guide's exact code snippets and values, not deviate from them
- **README update**: Add Step 4b to update `polkadot-docs/README.md` verified guides table
- **Companion PR gating**: Mandatory checkpoint between cookbook PR (6a) and companion PR (6b) — wait for user to say "go"
- **Test before commit**: Explicit rule to never commit untested code
- **Autonomous execution**: Skill should run end-to-end without prompting at each step
- **Badge format**: Companion PR badges use `status-badge` div wrapper + "View tests" link (matching existing guides)
- **Cross-linking**: New Step 6c to cross-link both PRs in their descriptions

## Test plan
- [ ] Next invocation of `/add-polkadot-docs-test` follows the updated instructions