### PR TITLE
Release v0.14.0

### DIFF
--- a/.github/releases/v0.14.0/RELEASE_NOTES.md
+++ b/.github/releases/v0.14.0/RELEASE_NOTES.md
@@ -1,0 +1,50 @@
+<div align="center">
+  <img src="cover.svg" alt="Release v0.14.0" width="100%" />
+</div>
+
+# Release v0.14.0
+
+Released: 2026-04-13
+
+## Summary
+
+This release adds four new polkadot-docs test harnesses covering smart contract development environments, NFT workflows, full-stack dApps, and chain-interaction transactions — giving developers automated verification that official tutorials stay working end-to-end. It also folds in post-v0.13.0 fixes to the release pipeline and release-notes tooling.
+
+## What's New
+
+### Documentation Tests
+- Added test harness for **Foundry dev environment** guide — developers can now verify the Foundry smart contract workflow on Polkadot Hub works before following it (#230)
+- Added test harness for the **NFT Hardhat** guide — the ERC-721 minting and deployment flow is now covered by CI, catching breaks in the NFT tutorial before users hit them (#228)
+- Added test harness for the **Zero-to-Hero dApp** guide — the full-stack tutorial is now verified end-to-end, so learners starting from scratch get a path that's known-good (#229)
+- Added test harness for the **Send Transactions** guide (chain-interactions pathway) with a Rust `subxt` binary, ensuring the transfer flow and metadata stay in sync with upstream (#232)
+
+### Infrastructure
+- Fixed `publish-release.yml` duplicate tag check so re-running the publish workflow no longer fails when the tag already exists (#254)
+- Added Mondrian cover art, wordmark, and release notes polish to the `/release` skill so every release ships with unique generative branding (#253)
+- Ensured every commit in release notes carries a `(#N)` PR link — makes rendered notes fully navigable on GitHub (#252)
+
+## Commits
+
+- feat: add send-transactions polkadot-docs test harness (#232)
+- feat: add nft-hardhat polkadot-docs test harness (#228)
+- feat: add zero-to-hero-dapp polkadot-docs test harness (#229)
+- feat: add foundry polkadot-docs test harness (#230)
+- fix: publish-release tag duplicate check (#254)
+- chore: add Mondrian cover art, branding, and release notes polish (#253)
+- chore: ensure all release note commits have PR links (#252)
+
+## Stats
+
+**7 commits, +16,595 / -14 lines**
+
+**Full Changelog:** https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.13.0...v0.14.0
+
+## Compatibility
+
+Tested with:
+- Rust: 1.91.0
+- Node.js: v24.7.0
+
+---
+
+**Status:** Alpha (v0.x.x)

--- a/.github/releases/v0.14.0/cover.svg
+++ b/.github/releases/v0.14.0/cover.svg
@@ -1,0 +1,77 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      @keyframes fade-block {
+        0%, 100% { opacity: 0.85; }
+        50% { opacity: 1; }
+      }
+      .block-animate { animation: fade-block 7s ease-in-out infinite; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#0D0D0D"/>
+
+  <!-- Mondrian grid lines — asymmetric, shifted from v0.13.0 -->
+  <g stroke="#2A2A2A" stroke-width="4">
+    <line x1="180" y1="0" x2="180" y2="630"/>
+    <line x1="460" y1="0" x2="460" y2="630"/>
+    <line x1="820" y1="0" x2="820" y2="630"/>
+    <line x1="0" y1="120" x2="1200" y2="120"/>
+    <line x1="0" y1="320" x2="1200" y2="320"/>
+    <line x1="0" y1="470" x2="1200" y2="470"/>
+  </g>
+
+  <!-- Color blocks — Polkadot palette -->
+  <!-- Primary pink blocks -->
+  <rect class="block-animate" x="184" y="4" width="272" height="112" fill="#E6007A" opacity="0.85"/>
+  <rect class="block-animate" x="824" y="124" width="372" height="192" fill="#E6007A" opacity="0.75" style="animation-delay: 1.2s;"/>
+  <rect class="block-animate" x="4" y="474" width="172" height="152" fill="#E6007A" opacity="0.55" style="animation-delay: 3.2s;"/>
+
+  <!-- Deep blue blocks -->
+  <rect class="block-animate" x="464" y="4" width="352" height="112" fill="#11116B" opacity="0.9" style="animation-delay: 0.6s;"/>
+  <rect class="block-animate" x="4" y="124" width="172" height="192" fill="#11116B" opacity="0.8" style="animation-delay: 2.1s;"/>
+  <rect class="block-animate" x="464" y="324" width="352" height="142" fill="#11116B" opacity="0.65" style="animation-delay: 1.8s;"/>
+
+  <!-- Accent blocks — lighter variants -->
+  <rect class="block-animate" x="184" y="324" width="272" height="142" fill="#E6007A" opacity="0.18" style="animation-delay: 2.7s;"/>
+  <rect class="block-animate" x="824" y="474" width="372" height="152" fill="#11116B" opacity="0.25" style="animation-delay: 3.6s;"/>
+  <rect class="block-animate" x="184" y="474" width="272" height="152" fill="#FFFFFF" opacity="0.06" style="animation-delay: 4.1s;"/>
+  <rect class="block-animate" x="824" y="4" width="372" height="112" fill="#FFFFFF" opacity="0.04" style="animation-delay: 5s;"/>
+
+  <!-- Polkadot dots — repositioned network nodes -->
+  <g fill="#E6007A">
+    <circle cx="90" cy="60" r="16" opacity="0.55"/>
+    <circle cx="320" cy="60" r="10" opacity="0.4"/>
+    <circle cx="1010" cy="220" r="18" opacity="0.55"/>
+    <circle cx="640" cy="395" r="12" opacity="0.5"/>
+    <circle cx="90" cy="395" r="14" opacity="0.4"/>
+    <circle cx="1120" cy="550" r="11" opacity="0.45"/>
+  </g>
+
+  <!-- Connection lines between dots — network mesh -->
+  <g stroke="#E6007A" stroke-width="1" opacity="0.15" fill="none">
+    <line x1="90" y1="60" x2="320" y2="60"/>
+    <line x1="320" y1="60" x2="1010" y2="220"/>
+    <line x1="1010" y1="220" x2="640" y2="395"/>
+    <line x1="640" y1="395" x2="90" y2="395"/>
+    <line x1="90" y1="395" x2="90" y2="60"/>
+    <line x1="1010" y1="220" x2="1120" y2="550"/>
+  </g>
+
+  <!-- Version text -->
+  <text x="1170" y="600" font-family="monospace" font-size="42" fill="#FFFFFF" opacity="0.15" text-anchor="end" font-weight="bold">v0.14.0</text>
+
+  <!-- Polkadot Cookbook wordmark -->
+  <text x="30" y="600" font-family="system-ui, -apple-system, sans-serif" font-size="16" fill="#FFFFFF" opacity="0.25" font-weight="500">POLKADOT COOKBOOK</text>
+
+  <!-- Bold overlay grid lines for Mondrian effect -->
+  <g stroke="#1A1A1A" stroke-width="6">
+    <line x1="180" y1="0" x2="180" y2="630"/>
+    <line x1="460" y1="0" x2="460" y2="630"/>
+    <line x1="820" y1="0" x2="820" y2="630"/>
+    <line x1="0" y1="120" x2="1200" y2="120"/>
+    <line x1="0" y1="320" x2="1200" y2="320"/>
+    <line x1="0" y1="470" x2="1200" y2="470"/>
+  </g>
+</svg>

--- a/.github/releases/v0.14.0/manifest.yml
+++ b/.github/releases/v0.14.0/manifest.yml
@@ -1,0 +1,8 @@
+release: v0.14.0
+previous_release: v0.13.0
+release_date: 2026-04-13T00:00:00Z
+status: alpha
+
+tooling:
+  rust: "1.91.0"
+  node: "v24.7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-13
+
+### Added
+- Test harness for **Foundry dev environment** polkadot-docs guide
+- Test harness for **NFT Hardhat** polkadot-docs guide
+- Test harness for **Zero-to-Hero dApp** polkadot-docs guide
+- Test harness for **Send Transactions** polkadot-docs guide with Rust subxt binary
+- Mondrian cover art, wordmark, and release notes polish in /release skill
+- Every release-notes commit now carries a `(#N)` PR link
+
+### Fixed
+- `publish-release.yml` duplicate tag check no longer fails on re-runs
+
 ## [0.13.0] - 2026-04-09
 
 ### Added
@@ -30,5 +43,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Source URLs after upstream docs restructured periphery page
 - CI cache key to reference `docs.test.ts` after test file rename
 
-[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.12.0...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["dot/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = ["Polkadot Cookbook Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
<div align="center">
  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/release/v0.14.0/.github/releases/v0.14.0/cover.svg" alt="Release v0.14.0" width="100%" />
</div>

# Release v0.14.0

Released: 2026-04-13

## Summary

This release adds four new polkadot-docs test harnesses covering smart contract development environments, NFT workflows, full-stack dApps, and chain-interaction transactions — giving developers automated verification that official tutorials stay working end-to-end. It also folds in post-v0.13.0 fixes to the release pipeline and release-notes tooling.

## What's New

### Documentation Tests
- Added test harness for **Foundry dev environment** guide — developers can now verify the Foundry smart contract workflow on Polkadot Hub works before following it (#230)
- Added test harness for the **NFT Hardhat** guide — the ERC-721 minting and deployment flow is now covered by CI, catching breaks in the NFT tutorial before users hit them (#228)
- Added test harness for the **Zero-to-Hero dApp** guide — the full-stack tutorial is now verified end-to-end, so learners starting from scratch get a path that's known-good (#229)
- Added test harness for the **Send Transactions** guide (chain-interactions pathway) with a Rust `subxt` binary, ensuring the transfer flow and metadata stay in sync with upstream (#232)

### Infrastructure
- Fixed `publish-release.yml` duplicate tag check so re-running the publish workflow no longer fails when the tag already exists (#254)
- Added Mondrian cover art, wordmark, and release notes polish to the `/release` skill so every release ships with unique generative branding (#253)
- Ensured every commit in release notes carries a `(#N)` PR link — makes rendered notes fully navigable on GitHub (#252)

## Commits

- feat: add send-transactions polkadot-docs test harness (#232)
- feat: add nft-hardhat polkadot-docs test harness (#228)
- feat: add zero-to-hero-dapp polkadot-docs test harness (#229)
- feat: add foundry polkadot-docs test harness (#230)
- fix: publish-release tag duplicate check (#254)
- chore: add Mondrian cover art, branding, and release notes polish (#253)
- chore: ensure all release note commits have PR links (#252)

## Stats

**7 commits, +16,595 / -14 lines**

**Full Changelog:** https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.13.0...v0.14.0

## Compatibility

Tested with:
- Rust: 1.91.0
- Node.js: v24.7.0

---

## Next Steps

Merging this PR triggers `publish-release.yml` on `master`, which will:
1. Create the `v0.14.0` git tag
2. Build CLI binaries for release artifacts
3. Publish the GitHub Release using these notes and cover art

**Status:** Alpha (v0.x.x)