### PR TITLE
Fix cover art broken image in release PR body

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -211,6 +211,14 @@ If `CHANGELOG.md` doesn't exist yet, create it with the header, `[Unreleased]` s
    - The full release notes content from Phase 3
    - A "Next Steps" section explaining that merging triggers `publish-release.yml` (tag creation, binary builds, GitHub Release)
 
+   **Cover art in PR body:** `RELEASE_NOTES.md` uses `src="cover.svg"` which works inside the release folder, but relative paths **do not resolve in PR descriptions** — the image will render broken. When copying the release notes into the PR body, rewrite the `<img>` `src` to the raw URL for the release branch:
+
+   ```
+   https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/release/vX.Y.Z/.github/releases/vX.Y.Z/cover.svg
+   ```
+
+   Do **not** modify `RELEASE_NOTES.md` itself — the relative path is correct for the file's context once merged.
+
 4. Report the PR URL.
 
 ---


### PR DESCRIPTION
## Summary

Relative image paths don't resolve in GitHub PR descriptions, so the Mondrian cover art in the release PR body rendered as a broken image icon (observed on #256).

This updates the \`/release\` skill to instruct rewriting the cover \`<img>\` \`src\` to a \`raw.githubusercontent.com\` URL for the release branch when copying release notes into the PR body. \`RELEASE_NOTES.md\` itself is left untouched — the relative path is correct for its own rendering context.

## Test plan

- [ ] Next release run produces a PR body with a rendered cover image
- [ ] \`RELEASE_NOTES.md\` inside the release folder still renders the cover via the relative path