### PR TITLE
fix(ci): wire polkadot_sdk version into run-a-parachain-network workflow

### DIFF
--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Load versions
         id: versions
         run: |
+          echo "POLKADOT_SDK_VERSION=$(yq '.polkadot_sdk.release_tag' versions.yml)" >> $GITHUB_OUTPUT
           echo "TEMPLATE_VERSION=$(yq '.parachain_template.version' versions.yml)" >> $GITHUB_OUTPUT
           echo "ZOMBIENET_VERSION=$(yq '.zombienet.version' versions.yml)" >> $GITHUB_OUTPUT
 
@@ -107,6 +108,8 @@ jobs:
         run: |
           cd polkadot-docs/networks/run-a-parachain-network
           npm test
+        env:
+          POLKADOT_SDK_VERSION: ${{ steps.versions.outputs.POLKADOT_SDK_VERSION }}
         timeout-minutes: 60
 
   post-test:

--- a/.github/workflows/polkadot-docs-run-a-parachain-network.yml
+++ b/.github/workflows/polkadot-docs-run-a-parachain-network.yml
@@ -7,11 +7,13 @@ on:
       - 'polkadot-docs/networks/run-a-parachain-network/**'
       - '!polkadot-docs/networks/run-a-parachain-network/README.md'
       - 'versions.yml'
+      - '.github/workflows/polkadot-docs-run-a-parachain-network.yml'
   pull_request:
     paths:
       - 'polkadot-docs/networks/run-a-parachain-network/**'
       - '!polkadot-docs/networks/run-a-parachain-network/README.md'
       - 'versions.yml'
+      - '.github/workflows/polkadot-docs-run-a-parachain-network.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The `run-a-parachain-network` test at `tests/docs.test.ts:11` reads `process.env.POLKADOT_SDK_VERSION` to download the relay binary from `paritytech/polkadot-sdk/releases/download/${POLKADOT_SDK_VERSION}`. The workflow never loaded `.polkadot_sdk.release_tag` from `versions.yml` or exported the env var.

Consequences:
- The `check-version-keys` guard auto-detects keys by parsing `yq` calls in the workflow — without the `polkadot_sdk` line, a `polkadot_sdk`-only bump (e.g. the recent upstream variables update that propagated into #1634 on polkadot-docs) did **not** trigger this workflow.
- Even on manual runs / unrelated triggers, the test would crash because `POLKADOT_SDK_VERSION` was undefined.

All sibling Zombienet workflows (`channels-between-parachains`, `channels-with-system-parachains`, `runtime-upgrades`, etc.) already load and export this key — this brings `run-a-parachain-network` in line.

## Test plan

- [ ] CI workflow triggers on this PR and exercises the new env plumbing
- [ ] `npm test` inside `polkadot-docs/networks/run-a-parachain-network/` succeeds with `POLKADOT_SDK_VERSION` populated from versions.yml