### PR TITLE
feat(release-skill): add --dry-run mode

### DIFF
--- a/.claude/skills/release/DRY_RUN.md
+++ b/.claude/skills/release/DRY_RUN.md
@@ -101,11 +101,11 @@ Render `$SCRATCH/pr-body.md` from [`RELEASE_PR_BODY.template.md`](RELEASE_PR_BOD
 
 ## Template rendering convention
 
-Each non-SVG template (`RELEASE_NOTES.template.md`, `MANIFEST.template.yml`, `RELEASE_PR_BODY.template.md`) starts with a **documentation header block** that explains tokens/markers for humans reading the template source. This header must be **stripped before rendering**:
+Every template file starts with a **documentation header block** that explains tokens and markers for humans reading the template source. This header must be **stripped before any substitution**, because the doc text often *names* the tokens/markers (`{{VERSION}}`, `<!-- @@COMMIT_LIST -->`) as examples — if you substitute into the doc text, you inject content where it doesn't belong, or (for SVGs) corrupt the XML comment structure with `--` characters from commit subjects.
 
-- **Markdown templates:** delete all lines from line 1 through the first empty line.
-- **YAML templates:** delete all contiguous leading lines that start with `#`.
-- **SVG templates:** do NOT strip. SVG comments are invisible in renders.
+- **Markdown templates** (`*.template.md`): delete all lines from line 1 through the first empty line.
+- **YAML templates** (`*.template.yml`): delete all contiguous leading lines that start with `#`.
+- **SVG templates** (`*.svg.template`): delete the first top-level `<!-- ... -->` comment block that appears before the first element content. The stripped block is purely documentation; the SVG remains valid without it.
 
 Then perform scalar substitution and marker fills on the remaining content.
 

--- a/.claude/skills/release/DRY_RUN.md
+++ b/.claude/skills/release/DRY_RUN.md
@@ -1,0 +1,161 @@
+# /release --dry-run
+
+Load this file when `/release` is invoked with `--dry-run`. **Do not** follow the real-run pipeline in `SKILL.md`; follow this file instead. The real-run pipeline is referenced only for its templates and data contracts, which are shared.
+
+## Invocation
+
+```
+/release --dry-run [patch|minor|major]
+```
+
+Previews every rendered release artifact in a scratch directory. **No git mutations. No GitHub mutations.** Safe to run any time.
+
+## What this does
+
+- Computes all scalar tokens + marker fills from git + RPC exactly as a real run would.
+- Renders every template (`cover.svg`, `cover-chain.svg`, `RELEASE_NOTES.md`, `manifest.yml`, PR body).
+- Writes outputs to `/tmp/release-dry-run/v{VERSION}/`.
+- Runs `xmllint --noout` on both SVGs.
+- Rewrites cover-image `src` attributes in `RELEASE_NOTES.md` and `pr-body.md` to relative paths (`./cover.svg`, `./cover-chain.svg`) so the scratch-dir Markdown previews render locally in VS Code / any previewer.
+- Prints a summary: scratch-dir path, per-file size/validity, unfilled token/marker counts.
+
+## What this does NOT do
+
+- No `git checkout -b release/vX.Y.Z`
+- No edits to `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` (proposed diff written to `proposed-changes.diff` instead)
+- No `git commit`, no `git push`
+- No `gh pr create`
+- No `gh release edit` on any existing release
+
+Chain-state RPC capture **does** run against live endpoints — it's cheap and is the only way to verify the endpoint walk + fallback logic. If all endpoints fail, the footer cover is marked `SKIPPED` in the summary.
+
+## Pipeline
+
+Each step below mirrors the real-run phase by the same number in `SKILL.md`. Only differences from real-run are called out — read the real-run phase for the shared logic.
+
+### Phase 1: Analyze changes
+
+Run exactly as in `SKILL.md` Phase 1 — read-only, no difference.
+
+### Phase 2: Bump logic
+
+Same as real-run. Determine `{{VERSION}}` from the bump arg + current `Cargo.toml`.
+
+### Phase 3 setup: scratch dir
+
+```bash
+SCRATCH=/tmp/release-dry-run/v{VERSION}
+mkdir -p $SCRATCH
+```
+
+All subsequent writes target `$SCRATCH` instead of `.github/releases/v{VERSION}/`.
+
+### Phase 3a: Gather metadata
+
+Exactly as real-run — commands are read-only.
+
+### Phase 3b: Release directory
+
+**Skip.** Real-run creates `.github/releases/v{VERSION}/` and commits a placeholder. In dry-run, the scratch dir replaces this.
+
+### Phase 3c: Top cover
+
+Render `$SCRATCH/cover.svg` from [`covers/cover.svg.template`](covers/cover.svg.template) per [`covers/cover.data.md`](covers/cover.data.md). Run `xmllint --noout` on output.
+
+### Phase 3c.2: Footer cover
+
+Render `$SCRATCH/cover-chain.svg` from [`covers/cover-chain.svg.template`](covers/cover-chain.svg.template) per [`covers/cover-chain.data.md`](covers/cover-chain.data.md). Walk the RPC endpoint list (live). If all fail: do not write the file, create `$SCRATCH/cover-chain.SKIPPED` with a one-line reason. Run `xmllint --noout` on output if written.
+
+### Phase 3d: Release notes
+
+Render `$SCRATCH/RELEASE_NOTES.md` from [`RELEASE_NOTES.template.md`](RELEASE_NOTES.template.md). **After substitution**, rewrite the two cover-image `<img src="...">` URLs:
+
+- `https://raw.githubusercontent.com/.../v{VERSION}/.github/releases/v{VERSION}/cover.svg` → `./cover.svg`
+- `https://raw.githubusercontent.com/.../v{VERSION}/.github/releases/v{VERSION}/cover-chain.svg` → `./cover-chain.svg`
+
+This makes the preview work in the scratch dir (the real `v{VERSION}` tag doesn't exist yet). Real-run keeps the absolute URLs.
+
+Fill marker sections (`@@SUMMARY`, `@@BREAKING`, `@@WHATS_NEW`, `@@COMMITS`) following `SKILL.md` Phase 3d narrative rules.
+
+### Phase 3e: CHANGELOG.md
+
+**Do not edit.** Compute the proposed new file content, diff against the current `CHANGELOG.md`:
+
+```bash
+diff -u CHANGELOG.md /tmp/proposed-changelog.md > $SCRATCH/proposed-changes.diff
+```
+
+Append the Cargo.toml version-bump one-liner to the same diff file.
+
+### Phase 3f: Cargo.toml
+
+**Do not edit.** Append the proposed `version = "X.Y.Z"` change to `$SCRATCH/proposed-changes.diff`. Skip `cargo update`.
+
+### Phase 3g: Manifest
+
+Render `$SCRATCH/manifest.yml` from [`MANIFEST.template.yml`](MANIFEST.template.yml).
+
+### Phase 4: PR body (no creation)
+
+Render `$SCRATCH/pr-body.md` from [`RELEASE_PR_BODY.template.md`](RELEASE_PR_BODY.template.md). Apply the same `./cover.svg` relative-path rewrite as Phase 3d. **Do not** create a branch, commit, push, or open a PR. Print what the `gh pr create` invocation would be.
+
+## Template rendering convention
+
+Each non-SVG template (`RELEASE_NOTES.template.md`, `MANIFEST.template.yml`, `RELEASE_PR_BODY.template.md`) starts with a **documentation header block** that explains tokens/markers for humans reading the template source. This header must be **stripped before rendering**:
+
+- **Markdown templates:** delete all lines from line 1 through the first empty line.
+- **YAML templates:** delete all contiguous leading lines that start with `#`.
+- **SVG templates:** do NOT strip. SVG comments are invisible in renders.
+
+Then perform scalar substitution and marker fills on the remaining content.
+
+## Exit criteria
+
+A clean dry-run must satisfy all of:
+
+- [ ] All six artifacts exist in `$SCRATCH`: `cover.svg`, `cover-chain.svg` OR `cover-chain.SKIPPED`, `RELEASE_NOTES.md`, `manifest.yml`, `pr-body.md`, `proposed-changes.diff`
+- [ ] `xmllint --noout` passes on both SVGs
+- [ ] Zero remaining `{{TOKEN}}` patterns in any rendered text file
+- [ ] Zero remaining `<!-- @@MARKER -->` comments (except `@@BREAKING` if intentionally omitted for no-breaking-change releases)
+- [ ] Sentinel checks — first non-empty line of each file must match:
+  - `RELEASE_NOTES.md` → `<div align="center">`
+  - `manifest.yml` → `release: v`
+  - `pr-body.md` → `<div align="center">`
+  - If any starts with `<!--` or `#`, the header-strip failed.
+
+If any check fails, report the failure and stop. A failing dry-run is a real-run bug caught early.
+
+## Summary output format
+
+Print at the end:
+
+```
+======================================================
+DRY RUN SUMMARY — v{VERSION}
+======================================================
+scratch dir: /tmp/release-dry-run/v{VERSION}/
+
+  cover.svg                 NN,NNN bytes  ✓ xmllint passes
+  cover-chain.svg           NN,NNN bytes  ✓ xmllint passes
+  RELEASE_NOTES.md          NN,NNN bytes  0 unfilled tokens / 0 unfilled markers
+  manifest.yml                 NNN bytes
+  pr-body.md                NN,NNN bytes
+  proposed-changes.diff      NN,NNN bytes  (CHANGELOG.md + Cargo.toml deltas)
+
+Preview:
+  open /tmp/release-dry-run/v{VERSION}/RELEASE_NOTES.md   # covers render via relative paths
+
+Would do on real run:
+  git checkout -b release/v{VERSION}
+  git add .github/releases/v{VERSION}/ Cargo.toml Cargo.lock CHANGELOG.md
+  git commit -m "Release v{VERSION}"
+  git push -u origin release/v{VERSION}
+  gh pr create --draft --title "Release v{VERSION}" --label release --body-file pr-body.md
+
+No mutations were performed. Open the scratch dir to review artifacts.
+======================================================
+```
+
+## Reset
+
+To clear a prior dry-run output: `rm -rf /tmp/release-dry-run/v{VERSION}/`

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,37 +9,7 @@ Create a versioned release of the Polkadot Cookbook. Accepts an optional bump ov
 
 **Contract with CI:** The `publish-release.yml` workflow triggers on merge to `master` when `.github/releases/v*/manifest.yml` changes. It builds CLI binaries, creates a git tag, and publishes the GitHub Release. This skill's job is to produce the artifacts that workflow expects.
 
----
-
-## Dry-Run Mode
-
-**`/release --dry-run [patch|minor|major]`** runs the full pipeline **without any git or GitHub mutations**. Use this to preview every rendered artifact before committing to a real release.
-
-What dry-run does:
-- Computes all scalar tokens + marker fills from git + RPC exactly as a real run would
-- Renders every template (`cover.svg`, `cover-chain.svg`, `RELEASE_NOTES.md`, `manifest.yml`, PR body)
-- Writes outputs to `/tmp/release-dry-run/v{VERSION}/` (not to `.github/releases/`)
-- Runs `xmllint --noout` on both SVGs
-- Prints a summary: the scratch-dir path, per-file size/validity, remaining un-substituted tokens (should be zero)
-
-What dry-run does **NOT** do:
-- No `git checkout -b release/vX.Y.Z`
-- No edits to `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` (print the proposed diff instead)
-- No `git commit`, no `git push`
-- No `gh pr create`
-- No `gh release edit` on any existing release
-
-The chain-state RPC capture (Phase 3c.2) **does** run against live endpoints — it's cheap (one HTTP burst) and it's the only way to verify the endpoint walk + fallback logic. If all endpoints fail, the dry-run marks the footer cover as `SKIPPED` in the summary, same as a real run would.
-
-Every phase below has a `**Dry-run:**` note describing its behavior under the flag. The rule is: if a phase's side effects are filesystem-local and reversible (template substitution), it runs and writes to the scratch dir. If a phase mutates git state or remote state, it prints what it would do instead.
-
-Exit criteria for a clean dry-run:
-- All six artifact files exist in `/tmp/release-dry-run/v{VERSION}/` (cover.svg, cover-chain.svg OR skip-notice, RELEASE_NOTES.md, manifest.yml, pr-body.md, and the proposed CHANGELOG/Cargo diffs as `proposed-changes.diff`)
-- `xmllint --noout` passes on both SVGs
-- Zero remaining `{{TOKEN}}` patterns in rendered output
-- Zero remaining `<!-- @@MARKER -->` comments in rendered output, except when a marker was intentionally omitted (e.g. `@@BREAKING` when there are no breaking changes)
-
-A clean dry-run is not a substitute for manual review of the narrative sections (`@@SUMMARY`, `@@WHATS_NEW`), but it does guarantee the scaffolding is correct.
+**If invoked with `--dry-run`, read [`DRY_RUN.md`](DRY_RUN.md) and follow that pipeline instead of the one below.** The real-run pipeline below makes git/GitHub mutations. Do not run it in dry-run mode.
 
 ---
 
@@ -110,8 +80,6 @@ GitHub squash merges often strip conventional commit prefixes (e.g., "Add featur
 - **Stats:** `git diff --shortstat {tag}..HEAD` and `git log --oneline {tag}..HEAD | wc -l` for commit count
 - **Diff link:** `https://github.com/polkadot-developers/polkadot-cookbook/compare/{tag}...v{new}`
 
-**Dry-run:** runs as normal — metadata gathering is read-only.
-
 ### 3b. Release directory and manifest
 
 Create `.github/releases/vX.Y.Z/` with `manifest.yml`:
@@ -128,8 +96,6 @@ tooling:
 ```
 
 Get actual tool versions from the local environment.
-
-**Dry-run:** substitute the scratch path `/tmp/release-dry-run/vX.Y.Z/` for `.github/releases/vX.Y.Z/` in every write. `mkdir -p` the scratch dir at phase start.
 
 ### 3c. Cover art (template-driven, fact-bound)
 
@@ -231,8 +197,6 @@ Tested with:
 
 </details>
 
-**Dry-run:** write `cover.svg` and `cover-chain.svg` (or skip-notice) to `/tmp/release-dry-run/vX.Y.Z/`. Write `RELEASE_NOTES.md` to the same dir — but use URLs pinned to `master` for the embedded cover images (the real tag doesn't exist in a dry-run, so rendering with `v{VERSION}` paths would 404 on GitHub).
-
 ### 3e. Update CHANGELOG.md
 
 Prepend the new release to `CHANGELOG.md` at the repository root (create the file if it doesn't exist). Follow the [Keep a Changelog](https://keepachangelog.com/) format.
@@ -268,22 +232,16 @@ At the bottom of the file, maintain a link reference section:
 
 If `CHANGELOG.md` doesn't exist yet, create it with the header, `[Unreleased]` section, and the current release only.
 
-**Dry-run:** do not write `CHANGELOG.md`. Compute the proposed new content, diff against the current file (`diff -u CHANGELOG.md /tmp/proposed.md`), and append the diff to `/tmp/release-dry-run/vX.Y.Z/proposed-changes.diff`.
-
 ### 3f. Update Cargo.toml and lockfile
 
 - Edit `Cargo.toml` `[workspace.package]` → `version = "X.Y.Z"` (strip `v` prefix)
 - Run `cargo update --workspace`
-
-**Dry-run:** do not edit `Cargo.toml`. Print the one-line change to `proposed-changes.diff`. Skip `cargo update`.
 
 ### 3g. Manifest (template-driven)
 
 Render `.github/releases/vX.Y.Z/manifest.yml` from [`MANIFEST.template.yml`](MANIFEST.template.yml). Substitute `{{VERSION}}`, `{{PREV_VERSION}}`, `{{RELEASE_DATE}}` (ISO-8601 UTC), `{{STATUS}}` (`alpha` while major=0, `beta` during 1.0 RC, `stable` thereafter), `{{RUST_VERSION}}`, `{{NODE_VERSION}}`. No markers — manifest is scalar-only.
 
 ---
-
-**Dry-run:** write `manifest.yml` to the scratch dir; do not touch `.github/releases/`.
 
 ## Phase 4: Create Release PR
 
@@ -309,34 +267,6 @@ Render `.github/releases/vX.Y.Z/manifest.yml` from [`MANIFEST.template.yml`](MAN
 4. Report the PR URL.
 
 ---
-
-**Dry-run:** do NOT create a branch, commit, push, or open a PR. Render the PR body from `RELEASE_PR_BODY.template.md` and write it to `/tmp/release-dry-run/vX.Y.Z/pr-body.md`. Print what the `gh pr create` invocation would be, including title and branch name. Then run the dry-run summary:
-
-```
-======================================================
-DRY RUN SUMMARY — vX.Y.Z
-======================================================
-scratch dir: /tmp/release-dry-run/vX.Y.Z/
-
-  cover.svg                 12,418 bytes  ✓ xmllint passes
-  cover-chain.svg           13,902 bytes  ✓ xmllint passes
-  RELEASE_NOTES.md           2,748 bytes  0 unfilled tokens / 0 unfilled markers
-  manifest.yml                 612 bytes
-  pr-body.md                 1,904 bytes
-  proposed-changes.diff      1,206 bytes  (CHANGELOG.md + Cargo.toml deltas)
-
-Would do on real run:
-  git checkout -b release/vX.Y.Z
-  git add .github/releases/vX.Y.Z/ Cargo.toml Cargo.lock CHANGELOG.md
-  git commit -m "Release vX.Y.Z"
-  git push -u origin release/vX.Y.Z
-  gh pr create --draft --title "Release vX.Y.Z" --label "release" --body-file pr-body.md
-
-No mutations were performed. Open the scratch dir to review artifacts.
-======================================================
-```
-
-Fail the dry-run loudly (exit non-zero-equivalent) if any exit-criteria check from the top-level "Dry-Run Mode" section fails. A dry-run with leftover `{{TOKENS}}` or failing `xmllint` is a real-release bug caught early.
 
 ## Phase 5: Self-Improvement
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut a new versioned release. Analyzes changes since last tag, determines semver bump, generates release notes and manifest, updates Cargo.toml and CHANGELOG.md, and opens a draft PR that triggers publish-release.yml on merge.
+description: Cut a new versioned release. Analyzes changes since last tag, determines semver bump, generates release notes and manifest, updates Cargo.toml and CHANGELOG.md, and opens a draft PR that triggers publish-release.yml on merge. Supports `--dry-run` to preview all artifacts in a scratch dir without any git or GitHub mutations.
 ---
 
 # Release
@@ -8,6 +8,38 @@ description: Cut a new versioned release. Analyzes changes since last tag, deter
 Create a versioned release of the Polkadot Cookbook. Accepts an optional bump override argument: `/release patch`, `/release minor`, or `/release major`. If no argument is given, the bump is determined automatically.
 
 **Contract with CI:** The `publish-release.yml` workflow triggers on merge to `master` when `.github/releases/v*/manifest.yml` changes. It builds CLI binaries, creates a git tag, and publishes the GitHub Release. This skill's job is to produce the artifacts that workflow expects.
+
+---
+
+## Dry-Run Mode
+
+**`/release --dry-run [patch|minor|major]`** runs the full pipeline **without any git or GitHub mutations**. Use this to preview every rendered artifact before committing to a real release.
+
+What dry-run does:
+- Computes all scalar tokens + marker fills from git + RPC exactly as a real run would
+- Renders every template (`cover.svg`, `cover-chain.svg`, `RELEASE_NOTES.md`, `manifest.yml`, PR body)
+- Writes outputs to `/tmp/release-dry-run/v{VERSION}/` (not to `.github/releases/`)
+- Runs `xmllint --noout` on both SVGs
+- Prints a summary: the scratch-dir path, per-file size/validity, remaining un-substituted tokens (should be zero)
+
+What dry-run does **NOT** do:
+- No `git checkout -b release/vX.Y.Z`
+- No edits to `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` (print the proposed diff instead)
+- No `git commit`, no `git push`
+- No `gh pr create`
+- No `gh release edit` on any existing release
+
+The chain-state RPC capture (Phase 3c.2) **does** run against live endpoints — it's cheap (one HTTP burst) and it's the only way to verify the endpoint walk + fallback logic. If all endpoints fail, the dry-run marks the footer cover as `SKIPPED` in the summary, same as a real run would.
+
+Every phase below has a `**Dry-run:**` note describing its behavior under the flag. The rule is: if a phase's side effects are filesystem-local and reversible (template substitution), it runs and writes to the scratch dir. If a phase mutates git state or remote state, it prints what it would do instead.
+
+Exit criteria for a clean dry-run:
+- All six artifact files exist in `/tmp/release-dry-run/v{VERSION}/` (cover.svg, cover-chain.svg OR skip-notice, RELEASE_NOTES.md, manifest.yml, pr-body.md, and the proposed CHANGELOG/Cargo diffs as `proposed-changes.diff`)
+- `xmllint --noout` passes on both SVGs
+- Zero remaining `{{TOKEN}}` patterns in rendered output
+- Zero remaining `<!-- @@MARKER -->` comments in rendered output, except when a marker was intentionally omitted (e.g. `@@BREAKING` when there are no breaking changes)
+
+A clean dry-run is not a substitute for manual review of the narrative sections (`@@SUMMARY`, `@@WHATS_NEW`), but it does guarantee the scaffolding is correct.
 
 ---
 
@@ -78,6 +110,8 @@ GitHub squash merges often strip conventional commit prefixes (e.g., "Add featur
 - **Stats:** `git diff --shortstat {tag}..HEAD` and `git log --oneline {tag}..HEAD | wc -l` for commit count
 - **Diff link:** `https://github.com/polkadot-developers/polkadot-cookbook/compare/{tag}...v{new}`
 
+**Dry-run:** runs as normal — metadata gathering is read-only.
+
 ### 3b. Release directory and manifest
 
 Create `.github/releases/vX.Y.Z/` with `manifest.yml`:
@@ -94,6 +128,8 @@ tooling:
 ```
 
 Get actual tool versions from the local environment.
+
+**Dry-run:** substitute the scratch path `/tmp/release-dry-run/vX.Y.Z/` for `.github/releases/vX.Y.Z/` in every write. `mkdir -p` the scratch dir at phase start.
 
 ### 3c. Cover art (template-driven, fact-bound)
 
@@ -195,6 +231,8 @@ Tested with:
 
 </details>
 
+**Dry-run:** write `cover.svg` and `cover-chain.svg` (or skip-notice) to `/tmp/release-dry-run/vX.Y.Z/`. Write `RELEASE_NOTES.md` to the same dir — but use URLs pinned to `master` for the embedded cover images (the real tag doesn't exist in a dry-run, so rendering with `v{VERSION}` paths would 404 on GitHub).
+
 ### 3e. Update CHANGELOG.md
 
 Prepend the new release to `CHANGELOG.md` at the repository root (create the file if it doesn't exist). Follow the [Keep a Changelog](https://keepachangelog.com/) format.
@@ -230,16 +268,22 @@ At the bottom of the file, maintain a link reference section:
 
 If `CHANGELOG.md` doesn't exist yet, create it with the header, `[Unreleased]` section, and the current release only.
 
+**Dry-run:** do not write `CHANGELOG.md`. Compute the proposed new content, diff against the current file (`diff -u CHANGELOG.md /tmp/proposed.md`), and append the diff to `/tmp/release-dry-run/vX.Y.Z/proposed-changes.diff`.
+
 ### 3f. Update Cargo.toml and lockfile
 
 - Edit `Cargo.toml` `[workspace.package]` → `version = "X.Y.Z"` (strip `v` prefix)
 - Run `cargo update --workspace`
+
+**Dry-run:** do not edit `Cargo.toml`. Print the one-line change to `proposed-changes.diff`. Skip `cargo update`.
 
 ### 3g. Manifest (template-driven)
 
 Render `.github/releases/vX.Y.Z/manifest.yml` from [`MANIFEST.template.yml`](MANIFEST.template.yml). Substitute `{{VERSION}}`, `{{PREV_VERSION}}`, `{{RELEASE_DATE}}` (ISO-8601 UTC), `{{STATUS}}` (`alpha` while major=0, `beta` during 1.0 RC, `stable` thereafter), `{{RUST_VERSION}}`, `{{NODE_VERSION}}`. No markers — manifest is scalar-only.
 
 ---
+
+**Dry-run:** write `manifest.yml` to the scratch dir; do not touch `.github/releases/`.
 
 ## Phase 4: Create Release PR
 
@@ -265,6 +309,34 @@ Render `.github/releases/vX.Y.Z/manifest.yml` from [`MANIFEST.template.yml`](MAN
 4. Report the PR URL.
 
 ---
+
+**Dry-run:** do NOT create a branch, commit, push, or open a PR. Render the PR body from `RELEASE_PR_BODY.template.md` and write it to `/tmp/release-dry-run/vX.Y.Z/pr-body.md`. Print what the `gh pr create` invocation would be, including title and branch name. Then run the dry-run summary:
+
+```
+======================================================
+DRY RUN SUMMARY — vX.Y.Z
+======================================================
+scratch dir: /tmp/release-dry-run/vX.Y.Z/
+
+  cover.svg                 12,418 bytes  ✓ xmllint passes
+  cover-chain.svg           13,902 bytes  ✓ xmllint passes
+  RELEASE_NOTES.md           2,748 bytes  0 unfilled tokens / 0 unfilled markers
+  manifest.yml                 612 bytes
+  pr-body.md                 1,904 bytes
+  proposed-changes.diff      1,206 bytes  (CHANGELOG.md + Cargo.toml deltas)
+
+Would do on real run:
+  git checkout -b release/vX.Y.Z
+  git add .github/releases/vX.Y.Z/ Cargo.toml Cargo.lock CHANGELOG.md
+  git commit -m "Release vX.Y.Z"
+  git push -u origin release/vX.Y.Z
+  gh pr create --draft --title "Release vX.Y.Z" --label "release" --body-file pr-body.md
+
+No mutations were performed. Open the scratch dir to review artifacts.
+======================================================
+```
+
+Fail the dry-run loudly (exit non-zero-equivalent) if any exit-criteria check from the top-level "Dry-Run Mode" section fails. A dry-run with leftover `{{TOKENS}}` or failing `xmllint` is a real-release bug caught early.
 
 ## Phase 5: Self-Improvement
 


### PR DESCRIPTION
## Summary

Adds a `--dry-run` mode to the `/release` skill. Invoked as `/release --dry-run [patch|minor|major]`, it runs the full pipeline against the real repo state but:

- Writes every rendered artifact to `/tmp/release-dry-run/v{VERSION}/` instead of `.github/releases/`
- Skips all git mutations (no branch, no commit, no push)
- Skips all GitHub mutations (no PR creation, no release edits)
- Prints the proposed `CHANGELOG.md` and `Cargo.toml` diffs instead of applying them

What still runs during a dry-run:
- Full data gathering (git log, git diff --shortstat, git shortlog)
- Live chain-state RPC capture against rpc.polkadot.io (and fallbacks) — cheap, and the only way to verify the endpoint-walk + fallback logic works
- Template substitution + marker filling on all five artifacts
- `xmllint --noout` on both SVGs

### Exit criteria (checked at end)

A clean dry-run verifies:
- All six artifacts exist in the scratch dir
- `xmllint` passes on `cover.svg` and `cover-chain.svg`
- Zero leftover `{{TOKEN}}` patterns in any rendered file
- Zero leftover `<!-- @@MARKER -->` comments (except intentionally omitted optional markers)

### Use case

Primary: interactive use inside a Claude Code session. Preview what a real \`/release\` would produce before committing to it. Catches template bugs, narrative section gaps, and chain-state RPC issues locally in seconds.

### Files changed

- `.claude/skills/release/SKILL.md` — new \"Dry-Run Mode\" section at the top; per-phase \`**Dry-run:**\` notes; dry-run summary template in Phase 4; frontmatter description updated so the flag surfaces in skill listings.

No new templates, no new data contracts. The dry-run reuses all existing scaffolding; it just redirects outputs and skips git/gh.

## Test plan

- [ ] Invoke \`/release --dry-run patch\` in a session; verify all six artifacts appear in \`/tmp/release-dry-run/v{VERSION}/\`
- [ ] Open \`cover.svg\` and \`cover-chain.svg\` in the browser — both render correctly
- [ ] \`grep -rE '\\{\\{[A-Z_]+\\}\\}' /tmp/release-dry-run/v{VERSION}/\` returns zero matches
- [ ] \`xmllint --noout\` on both SVGs exits 0
- [ ] No new branch, commit, or PR created in the repo
- [ ] \`CHANGELOG.md\` and \`Cargo.toml\` unchanged; proposed changes visible in \`proposed-changes.diff\`