### PR TITLE
chore(release-skill): add argument-hint for --dry-run

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: release
 description: Cut a new versioned release. Analyzes changes since last tag, determines semver bump, generates release notes and manifest, updates Cargo.toml and CHANGELOG.md, and opens a draft PR that triggers publish-release.yml on merge. Supports `--dry-run` to preview all artifacts in a scratch dir without any git or GitHub mutations.
+argument-hint: "[--dry-run] [patch|minor|major]"
 ---
 
 # Release


### PR DESCRIPTION
Mirrors the `add-polkadot-docs-test` skill's `argument-hint` frontmatter so `/release` shows its optional args (`[--dry-run] [patch|minor|major]`) inline in the Claude Code slash-command UI. One-line frontmatter addition.

## Test plan

- [ ] Typing `/release ` in Claude Code prompt shows the hint `[--dry-run] [patch|minor|major]`