### PR TITLE
fix(release-skill): TEMPLATE_HEADER_END sentinels for unambiguous stripping

### DIFF
--- a/.claude/skills/release/DRY_RUN.md
+++ b/.claude/skills/release/DRY_RUN.md
@@ -101,13 +101,31 @@ Render `$SCRATCH/pr-body.md` from [`RELEASE_PR_BODY.template.md`](RELEASE_PR_BOD
 
 ## Template rendering convention
 
-Every template file starts with a **documentation header block** that explains tokens and markers for humans reading the template source. This header must be **stripped before any substitution**, because the doc text often *names* the tokens/markers (`{{VERSION}}`, `<!-- @@COMMIT_LIST -->`) as examples — if you substitute into the doc text, you inject content where it doesn't belong, or (for SVGs) corrupt the XML comment structure with `--` characters from commit subjects.
+Every template file starts with a **documentation header block** that explains tokens and markers for humans reading the template source. The doc text often *names* the tokens/markers (`{{VERSION}}`, `<!-- @@COMMIT_LIST -->`) as examples — if you substitute into the doc text, you inject content where it doesn't belong, or (for SVGs) corrupt the XML comment structure with `--` characters from commit subjects.
 
-- **Markdown templates** (`*.template.md`): delete all lines from line 1 through the first empty line.
-- **YAML templates** (`*.template.yml`): delete all contiguous leading lines that start with `#`.
-- **SVG templates** (`*.svg.template`): delete the first top-level `<!-- ... -->` comment block that appears before the first element content. The stripped block is purely documentation; the SVG remains valid without it.
+Every template ends its doc header with an unambiguous sentinel line:
 
-Then perform scalar substitution and marker fills on the remaining content.
+- **Markdown / SVG templates**: `<!-- TEMPLATE_HEADER_END -->`
+- **YAML templates**: `# TEMPLATE_HEADER_END`
+
+**Strip rule:** delete all lines from line 1 up to **and including** the sentinel line, plus any immediately-following blank line. Use a simple line scan — do not use a regex against the comment delimiters, because doc headers may contain nested-looking `<!-- @@MARKER -->` references.
+
+```python
+lines = template.splitlines(keepends=True)
+body_start = None
+for i, line in enumerate(lines):
+    if "TEMPLATE_HEADER_END" in line:
+        body_start = i + 1
+        # consume one trailing blank line if present
+        if body_start < len(lines) and lines[body_start].strip() == "":
+            body_start += 1
+        break
+if body_start is None:
+    fail("template is missing TEMPLATE_HEADER_END sentinel")
+template = "".join(lines[body_start:])
+```
+
+Then perform scalar substitution and marker fills on the remaining content. If a template is missing the sentinel, abort — do not attempt ad-hoc stripping.
 
 ## Exit criteria
 

--- a/.claude/skills/release/MANIFEST.template.yml
+++ b/.claude/skills/release/MANIFEST.template.yml
@@ -13,6 +13,7 @@
 #   {{RUST_VERSION}}     e.g. 1.91.0
 #   {{NODE_VERSION}}     e.g. v24.7.0
 # =============================================================================
+# TEMPLATE_HEADER_END
 
 release: v{{VERSION}}
 previous_release: v{{PREV_VERSION}}

--- a/.claude/skills/release/RELEASE_NOTES.template.md
+++ b/.claude/skills/release/RELEASE_NOTES.template.md
@@ -25,6 +25,7 @@
        <!-- @@COMMITS -->       Bulleted list of commit subjects with PR links,
                                 one line per commit, newest first.
      ============================================================================= -->
+<!-- TEMPLATE_HEADER_END -->
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v{{VERSION}}/.github/releases/v{{VERSION}}/cover.svg" alt="Release v{{VERSION}}" width="100%" />

--- a/.claude/skills/release/RELEASE_PR_BODY.template.md
+++ b/.claude/skills/release/RELEASE_PR_BODY.template.md
@@ -27,6 +27,7 @@
        commit SHA, not the branch name (`release/v{VERSION}`) — the branch is
        deleted on merge and branch-based raw URLs break retroactively.
      ============================================================================= -->
+<!-- TEMPLATE_HEADER_END -->
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/{{HEAD_SHA}}/.github/releases/v{{VERSION}}/cover.svg" alt="Release v{{VERSION}}" width="100%" />

--- a/.claude/skills/release/covers/cover-chain.svg.template
+++ b/.claude/skills/release/covers/cover-chain.svg.template
@@ -42,6 +42,7 @@
 
      No variable-count markers — the chain readout is fixed-shape.
      ========================================================================== -->
+<!-- TEMPLATE_HEADER_END -->
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
   <rect width="1200" height="630" fill="#0D0D0D"/>

--- a/.claude/skills/release/covers/cover.svg.template
+++ b/.claude/skills/release/covers/cover.svg.template
@@ -31,6 +31,7 @@
          <!-- @@COMMIT_TYPES -->       feat/fix/release tallies
          <!-- @@REPO_STATE -->         current counts in B5
        ========================================================================== -->
+  <!-- TEMPLATE_HEADER_END -->
 
   <rect width="1200" height="630" fill="#0D0D0D"/>
 


### PR DESCRIPTION
## Summary

Follow-up to PR #262. The v0.14.1 manual dry-run against the new pipeline surfaced two related bugs in the template-header strip logic documented in `DRY_RUN.md`:

1. **"Strip through first blank line"** — fails because MD/YAML template doc headers contain internal blank lines between sections.
2. **"Strip the first `<!-- -->` block via regex"** — fails for SVG and MD templates whose doc comments contain nested-looking `<!-- @@MARKER -->` references. Non-greedy regex matches the inner `-->`, not the outer.

Both bugs were **caught** by the sentinel exit checks added in PR #262 (rendered RELEASE_NOTES.md must start with `<div`, manifest.yml must start with `release:`) — the dry-run refused to consider the render clean and surfaced the failure before the user could ship a broken release.

## Fix

Every template now ends its doc header with an unambiguous sentinel line:

- **Markdown / SVG templates** (`*.template.md`, `*.svg.template`): `<!-- TEMPLATE_HEADER_END -->`
- **YAML templates** (`*.template.yml`): `# TEMPLATE_HEADER_END`

DRY_RUN.md's strip rule now does a simple line scan for the sentinel — no regex, no ambiguity. If a template is missing the sentinel, the pipeline aborts rather than attempt ad-hoc stripping.

## Files changed

- `.claude/skills/release/RELEASE_NOTES.template.md` — add sentinel
- `.claude/skills/release/RELEASE_PR_BODY.template.md` — add sentinel
- `.claude/skills/release/MANIFEST.template.yml` — add sentinel
- `.claude/skills/release/covers/cover.svg.template` — add sentinel
- `.claude/skills/release/covers/cover-chain.svg.template` — add sentinel
- `.claude/skills/release/DRY_RUN.md` — update strip rule with line-scan algorithm

## Test plan

- [x] All five templates strip to their expected body-start lines (`<div` / `release:` / `<rect` / `<svg`) — verified via scripted round-trip
- [ ] Run `/release --dry-run patch` after merge — all exit-criteria sentinel checks should pass without further intervention