### PR TITLE
Release v0.15.0

### DIFF
--- a/.github/releases/v0.15.0/RELEASE_NOTES.md
+++ b/.github/releases/v0.15.0/RELEASE_NOTES.md
@@ -1,0 +1,85 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.15.0/.github/releases/v0.15.0/cover.svg" alt="Release v0.15.0" width="100%" />
+</div>
+
+# Release v0.15.0
+
+Released: 2026-04-16
+
+## Summary
+
+v0.15.0 delivers a complete brand system refactor: every visual surface — README hero, dividers, social preview, OG image, per-pathway banners, CONTRIBUTING hero, favicon, and the release skill's cover art — now derives from a strict 3-color Polkadot palette (#E6007A pink, black, white) via tokens in `.github/brand/`, with CI-enforced palette discipline, drift prevention, and a11y checks. Also ships the `/release --dry-run` mode, a new chain-state footer cover pulled live via JSON-RPC at release-cut time, and one new polkadot-docs test harness (Transfer Assets Across Parachains).
+
+
+
+## What's New
+
+### Brand System
+
+- feat(brand): mondrian brand system, /branding skill, and CI enforcement — continuous refinement of the Cookbook's visual identity (#266)
+
+### Release Skill
+
+- fix(release-skill): TEMPLATE_HEADER_END sentinels for unambiguous stripping (#264)
+- chore(release-skill): add argument-hint for --dry-run — preview every rendered release artifact without any git or GitHub mutations (#263)
+- feat(release-skill): add --dry-run mode — preview every rendered release artifact without any git or GitHub mutations (#262)
+- feat(release-skill): footer cover-chain with Polkadot network reading — every release now captures a point-in-time reading of Polkadot mainnet (block number, runtime spec version, node version) via JSON-RPC (#261)
+- feat(release-skill): template-driven fact-bound cover art — cover art is now fact-bound to git facts — no hand-designed per-release variations (b67f316)
+
+### Documentation Tests
+
+- feat: add transfer-assets-parachains polkadot-docs test harness — developers can verify cross-chain asset transfer flows work end-to-end before touching production (#258)
+
+### Dependencies
+
+- chore(polkadot-api): bump to v2.0.1 and refactor harnesses — harnesses now pin polkadot-api v2.0.1 with cleaner imports (#265)
+
+### CI / Infrastructure
+
+- fix(ci): wire polkadot_sdk version into run-a-parachain-network workflow — CI now drives the parachain network test from the canonical polkadot_sdk version in versions.yml (#260)
+
+### Documentation
+
+- chore: document frontmatter badge pattern in add-polkadot-docs-test skill — the /add-polkadot-docs-test skill now documents how to add the polkadot-docs CI-badge frontmatter (#259)
+
+## Commits
+
+- feat(release-skill): add --dry-run mode (#262)
+- feat: add transfer-assets-parachains polkadot-docs test harness (#258)
+- feat(brand): mondrian brand system, /branding skill, and CI enforcement (#266)
+- feat(release-skill): template-driven fact-bound cover art (b67f316)
+- feat(release-skill): footer cover-chain with Polkadot network reading (#261)
+- fix(release-skill): TEMPLATE_HEADER_END sentinels for unambiguous stripping (#264)
+- fix(ci): wire polkadot_sdk version into run-a-parachain-network workflow (#260)
+- chore(polkadot-api): bump to v2.0.1 and refactor harnesses (#265)
+- chore(release-skill): add argument-hint for --dry-run (#263)
+- chore: document frontmatter badge pattern in add-polkadot-docs-test skill (#259)
+
+## Stats
+
+**10 commits, +11,944 / -8,420 lines**
+
+**Full Changelog:** https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.14.0...v0.15.0
+
+## Compatibility
+
+Tested with:
+- Rust: 1.91.0
+- Node.js: v24.7.0
+
+## Next Steps
+
+Merging the release PR triggers [`publish-release.yml`](../../../.github/workflows/publish-release.yml), which:
+1. Creates the `v0.15.0` git tag
+2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
+3. Publishes the GitHub Release with cover art, manifest, and binaries attached
+
+---
+
+**Status:** Alpha (v0.x.x)
+
+---
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.15.0/.github/releases/v0.15.0/cover-chain.svg" alt="Polkadot network state at v0.15.0 release" width="100%" />
+</div>

--- a/.github/releases/v0.15.0/cover-chain.svg
+++ b/.github/releases/v0.15.0/cover-chain.svg
@@ -1,0 +1,248 @@
+
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  <rect width="1200" height="630" fill="#000000"/>
+
+  <!-- ========== MONDRIAN GRID + BLOCKS (same geometry as top cover) ========== -->
+
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#000000">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 RUNTIME TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#000000"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#FFFFFF" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ polkadot runtime @ block 30,823,365 ├────────┐
+    </text>
+
+    <text x="774" y="46" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.7s" fill="freeze"/>
+      │ spec_name         polkadot
+    </text>
+    <text x="774" y="60" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.9s" fill="freeze"/>
+      │ spec_version      2,001,001
+    </text>
+    <text x="774" y="74" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.1s" fill="freeze"/>
+      │ impl_name         parity-polkadot
+    </text>
+    <text x="774" y="88" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.3s" fill="freeze"/>
+      │ node              1.22.0-2e4dd0bc223
+    </text>
+    <text x="774" y="102" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.5s" fill="freeze"/>
+      │ authoring_version 0
+    </text>
+    <text x="774" y="116" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.7s" fill="freeze"/>
+      │ transaction_ver   26
+    </text>
+    <text x="774" y="130" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.9s" fill="freeze"/>
+      │ state_version     1
+    </text>
+    <text x="774" y="144" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="3.1s" fill="freeze"/>
+      │ system_version    1
+    </text>
+    <text x="774" y="158" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0">
+      <animate attributeName="opacity" values="0;0.95" dur="0.15s" begin="3.4s" fill="freeze"/>
+      │ runtime_apis      23 exposed
+    </text>
+
+    <text x="774" y="196" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ state_root  0xd93de7c2..  genesis  0x91b171bb..
+    </text>
+    <text x="774" y="210" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ ss58 0 · DOT · 10 decimals · 6s block target
+    </text>
+    <text x="774" y="224" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0.55" letter-spacing="0.4">
+      └─ rpc.ibp.network · peers 28 · synced ✓ ─────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#000000">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#000000" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#000000" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <!-- No tip-pulse animation: this is a point-in-time reading, not a live chain tip -->
+
+  <!-- ========== FACTUAL OVERLAYS ========== -->
+
+  <!-- B1 PINK: headline + release-time disclaimer badge -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <!-- Disclaimer (the ONE place point-in-time nature is stated) -->
+    <g>
+      <rect x="410" y="22" width="318" height="114" fill="#000000" opacity="0.5" stroke="#FFFFFF" stroke-opacity="0.8" stroke-width="1"/>
+      <text x="432" y="52" font-size="11" font-weight="700" letter-spacing="1.8" opacity="0.98">◆ POINT-IN-TIME READING</text>
+      <text x="432" y="82" font-size="13" font-weight="700" opacity="0.95">polkadot-cookbook v0.15.0</text>
+      <text x="432" y="104" font-size="10" opacity="0.75">captured 2026-04-16 03:43 UTC</text>
+      <text x="432" y="122" font-size="10" opacity="0.6">mainnet state at release — not live</text>
+    </g>
+
+    <!-- Corner tag -->
+    <text x="36" y="34" font-size="10" letter-spacing="1.5" opacity="0.85">[0x91b171bb] GENESIS</text>
+
+    <!-- Headline -->
+    <text x="36" y="156" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">POLKADOT</text>
+    <text x="36" y="180" font-size="11" letter-spacing="2.5" opacity="0.75">
+      MAINNET  ·  rpc.ibp.network
+    </text>
+
+    <rect x="36" y="204" width="670" height="1" fill="#FFFFFF" opacity="0.35"/>
+
+    <text x="36" y="230" font-size="10" letter-spacing="1.5" opacity="0.65">FINALIZED BLOCK</text>
+    <text x="36" y="278" font-size="48" font-weight="700" letter-spacing="-0.5" opacity="0.95">#30,823,365</text>
+    <text x="36" y="300" font-size="11" opacity="0.55">0x6fd26350..a4bc</text>
+
+    <text x="36" y="340" font-size="10" letter-spacing="1.5" opacity="0.65">NETWORK AGE</text>
+    <text x="36" y="362" font-size="13" opacity="0.9"><tspan fill="#FFFFFF" font-weight="700">~5 years, 10 months</tspan>  <tspan opacity="0.55">since 2020-05-26</tspan></text>
+    <text x="36" y="380" font-size="11" opacity="0.6">block 0 → 30,823,365</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SPEC callout -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">RUNTIME SPEC</text>
+    <text x="772" y="316" font-size="26" font-weight="700" opacity="0.95">2,001,001</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">polkadot runtime</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">tx v26 · state v1</text>
+  </g>
+
+  <!-- Empty cell: ref node health -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">REF NODE HEALTH</text>
+    <text x="946" y="302" font-size="12" opacity="0.85">peers       <tspan fill="#E6007A">████████████</tspan>  82</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">syncing     <tspan fill="#E6007A">✓</tspan>     false</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">authoring   <tspan opacity="0.5">—</tspan>     v0</text>
+    <text x="946" y="368" font-size="10" opacity="0.45">NODE  parity-polkadot 1.22.0-2e4dd0bc223</text>
+  </g>
+
+  <!-- B3 BIG BLUE: network at a glance -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">NETWORK AT A GLANCE</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">[PARA::0] RELAY</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#FFFFFF" opacity="0.25"/>
+
+    <text x="320" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCKS FINALIZED</text>
+    <text x="320" y="514" font-size="28" font-weight="700" opacity="0.95">30,823,365</text>
+    <text x="320" y="534" font-size="10" opacity="0.5">cumulative since genesis</text>
+
+    <text x="560" y="480" font-size="11" letter-spacing="1" opacity="0.6">RUNTIME APIS</text>
+    <text x="560" y="514" font-size="28" font-weight="700" opacity="0.95">23</text>
+    <text x="560" y="534" font-size="10" opacity="0.5">exposed by runtime</text>
+
+    <text x="760" y="480" font-size="11" letter-spacing="1" opacity="0.6">REF NODE PEERS</text>
+    <text x="760" y="514" font-size="28" font-weight="700" opacity="0.95">28</text>
+    <text x="760" y="534" font-size="10" opacity="0.5">via rpc.ibp.network</text>
+
+    <text x="920" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCK TARGET</text>
+    <text x="920" y="514" font-size="28" font-weight="700" opacity="0.95">6s</text>
+    <text x="920" y="534" font-size="10" opacity="0.5">babe slot · network parameter</text>
+
+    <text x="320" y="580" font-size="10" opacity="0.55">Token DOT · 10 decimals · SS58 format 0 · relay chain · para_id 0</text>
+    <text x="320" y="594" font-size="10" opacity="0.45">State root 0xd93de7c2..4cfb  ·  Genesis 0x91b171bb..ce90c3</text>
+    <text x="320" y="612" font-size="10" opacity="0.55">queried via JSON-RPC  ·  methods: chain_getFinalizedHead · chain_getHeader · state_getRuntimeVersion · system_*</text>
+  </g>
+
+  <!-- B5: chain identity (was the live chain-tip block; now static) -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">
+      <tspan fill="#E6007A" opacity="0.9">◆</tspan> AT COOKBOOK v0.15.0
+    </text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#FFFFFF" opacity="0.25"/>
+
+    <text x="18" y="466" font-size="13" opacity="0.95">CHAIN      <tspan fill="#E6007A" font-weight="700">Polkadot</tspan></text>
+    <text x="18" y="486" font-size="13" opacity="0.95">TYPE       relay</text>
+    <text x="18" y="506" font-size="13" opacity="0.95">PARA_ID    0</text>
+    <text x="18" y="526" font-size="13" opacity="0.95">TOKEN      <tspan fill="#E6007A" font-weight="700">DOT</tspan>  <tspan opacity="0.6">(10 dec)</tspan></text>
+    <text x="18" y="546" font-size="13" opacity="0.95">SS58       0</text>
+    <text x="18" y="566" font-size="13" opacity="0.95">AUTHORING  BABE</text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 0x6fd26350</text>
+  </g>
+
+  <!-- H2 tickertape — scrolling reference data (ecosystem context, not live feed).
+       Loops slowly so readers can catch all of it; the B1 disclaimer makes the
+       point-in-time nature explicit, so motion here reads as caption, not live data. -->
+  <clipPath id="tick-clip">
+    <rect x="0" y="390" width="1200" height="14"/>
+  </clipPath>
+  <g clip-path="url(#tick-clip)" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="5.3s" fill="freeze"/>
+    <text y="401" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0.9" letter-spacing="0.8">
+      <animate attributeName="x" from="1200" to="-2800" dur="75s" repeatCount="indefinite" begin="5.3s"/>
+      POLKADOT RELAY  ·  PARA_ID 0  ·  SS58 0  ·  DOT (10 dec)  ·  GENESIS 2020-05-26  ·  BLOCK 0 HASH 0x91b171bb..ce90c3  ·  6s BLOCK TARGET · ≈14,400 blocks/day  ·  BLOCK 30,823,365 · HEAD 0x6fd26350..a4bc  ·  PARENT 0x6bb1799f..ef2b  ·  STATE ROOT 0xd93de7c2..4cfb  ·  EXTRINSICS ROOT 0x5412ca6c..4e7e  ·  RUNTIME SPEC 2,001,001 · 23 APIS · TX_VERSION 26 · STATE_VERSION 1 · SYSTEM_VERSION 1 · AUTHORING_VERSION 0  ·  NODE parity-polkadot 1.22.0-2e4dd0bc223  ·  QUERIED VIA rpc.ibp.network  ·  polkadot-cookbook v0.15.0 verified against this runtime
+    </text>
+  </g>
+</svg>

--- a/.github/releases/v0.15.0/cover.svg
+++ b/.github/releases/v0.15.0/cover.svg
@@ -1,0 +1,203 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  
+
+  <rect width="1200" height="630" fill="#000000"/>
+
+  <!-- B1 genesis pink -->
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#000000">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#000000"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#FFFFFF" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ v0.14.0..v0.15.0  2026-04-15 → 04-16 ├────────┐
+    </text>
+
+    <text x="774" y="46" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.70s" fill="freeze"/> │ acb05e5 ✓ chore: document frontmatter badge patter</text>
+    <text x="774" y="60" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.90s" fill="freeze"/> │ 30b96cc » feat: add transfer-assets-parachains pol</text>
+    <text x="774" y="74" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.10s" fill="freeze"/> │ a85f2c2 ✓ fix(ci): wire polkadot_sdk version into </text>
+    <text x="774" y="88" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.30s" fill="freeze"/> │ b67f316 » feat(release-skill): template-driven fac</text>
+    <text x="774" y="102" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.50s" fill="freeze"/> │ e94dff7 » feat(release-skill): footer cover-chain </text>
+    <text x="774" y="116" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.70s" fill="freeze"/> │ 0437a3a » feat(release-skill): add --dry-run mode </text>
+    <text x="774" y="130" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.90s" fill="freeze"/> │ 971ca2e ✓ chore(release-skill): add argument-hint </text>
+    <text x="774" y="144" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="3.10s" fill="freeze"/> │ 0208d86 ✓ fix(release-skill): TEMPLATE_HEADER_END </text>
+    <text x="774" y="158" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="3.30s" fill="freeze"/> │ 4feec19 ✓ chore(polkadot-api): bump to v2.0.1 and </text>
+    <text x="774" y="172" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="10" fill="#FFFFFF" opacity="0"><animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="3.50s" fill="freeze"/> │ 65b352c » feat(brand): mondrian brand system, /bra</text>
+
+    <text x="774" y="196" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ 10 commits · 1 contrib · +11,944 / -8,420 · 91 files
+    </text>
+    <text x="774" y="210" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ PRs #258 #259 #260 #261 #262 #263 #264 #265 #266
+    </text>
+    <text x="774" y="224" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#FFFFFF" opacity="0.55" letter-spacing="0.4">
+      └─ HEAD 65b352c · TAG v0.15.0 ─────────────────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#000000">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#000000" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#000000" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#FFFFFF" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#000000">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;0.2;0;0.2;0" keyTimes="0;0.25;0.5;0.75;1"
+             dur="4s" begin="6.5s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- B1 PINK overlay: headline + activity + contributors -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <text x="36" y="108" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">v0.15.0</text>
+    <text x="36" y="134" font-size="11" letter-spacing="2.5" opacity="0.75">
+      MINOR RELEASE  ·  2026-04-15 → 04-16  ·  1 DAYS
+    </text>
+
+    <rect x="36" y="158" width="670" height="1" fill="#FFFFFF" opacity="0.35"/>
+
+    <text x="36" y="182" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT ACTIVITY</text>
+
+    <text x="36" y="208" font-size="12" opacity="0.9">Thu 04-16  ●●<tspan opacity="0.6">  2 commits</tspan></text>
+    <text x="36" y="226" font-size="12" opacity="0.9">Wed 04-15  ●●●●●●●●<tspan opacity="0.6">  8 commits</tspan></text>
+
+    <text x="36" y="320" font-size="10" letter-spacing="1.5" opacity="0.65">CONTRIBUTORS</text>
+
+    <text x="36" y="342" font-size="12" opacity="0.9">Bruno Galvao      </text>
+    <rect x="180" y="333" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="100" dur="0.6s" begin="1.30s" fill="freeze"/></rect>
+    <text x="290" y="342" font-size="12" opacity="0.95" font-weight="700">10</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SEMVER -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">SEMVER</text>
+    <text x="772" y="312" font-size="22" font-weight="700" opacity="0.95">MINOR</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">0.14.0 → 0.15.0</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">1 days · +11,944</text>
+  </g>
+
+  <!-- Empty cell: COMMIT TYPES -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT TYPES</text>
+
+    <text x="946" y="302" font-size="12" opacity="0.85">» feat    </text>
+    <rect x="1026" y="293" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="60" dur="0.5s" begin="4.20s" fill="freeze"/></rect>
+    <text x="1096" y="302" font-size="12" opacity="0.95" font-weight="700">5</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">✓ fix     </text>
+    <rect x="1026" y="311" width="0" height="10" fill="#E6007A" opacity="0.55"><animate attributeName="width" from="0" to="60" dur="0.5s" begin="4.35s" fill="freeze"/></rect>
+    <text x="1096" y="320" font-size="12" opacity="0.95" font-weight="700">5</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">◆ release </text>
+    <rect x="1026" y="329" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="0" dur="0.5s" begin="4.50s" fill="freeze"/></rect>
+    <text x="1036" y="338" font-size="12" opacity="0.95" font-weight="700">0</text>
+
+    <text x="946" y="368" font-size="10" opacity="0.45">SCOPES  brand · ci · polkadot-api · release-skill</text>
+  </g>
+
+  <!-- B3 BIG BLUE: bar chart -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">FILES CHANGED BY AREA</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">91 TOTAL</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#FFFFFF" opacity="0.25"/>
+
+    <text x="320" y="466" font-size="12" opacity="0.9">polkadot-docs/chain-interactions</text>
+    <rect x="600" y="457" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="500" dur="0.70s" begin="3.30s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1110" y="466" font-size="12" opacity="0.95" font-weight="700">25</text>
+    <text x="320" y="484" font-size="12" opacity="0.9">.claude/skills</text>
+    <rect x="600" y="475" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="460" dur="0.68s" begin="3.40s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1070" y="484" font-size="12" opacity="0.95" font-weight="700">23</text>
+    <text x="320" y="502" font-size="12" opacity="0.9">.github/media</text>
+    <rect x="600" y="493" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="300" dur="0.62s" begin="3.50s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="910" y="502" font-size="12" opacity="0.95" font-weight="700">15</text>
+    <text x="320" y="520" font-size="12" opacity="0.9">.github/brand</text>
+    <rect x="600" y="511" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="200" dur="0.58s" begin="3.60s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="810" y="520" font-size="12" opacity="0.95" font-weight="700">10</text>
+    <text x="320" y="538" font-size="12" opacity="0.9">.github/workflows</text>
+    <rect x="600" y="529" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="80" dur="0.53s" begin="3.70s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="690" y="538" font-size="12" opacity="0.95" font-weight="700">4</text>
+    <text x="320" y="556" font-size="12" opacity="0.9">.github/ISSUE_TEMPLATE</text>
+    <rect x="600" y="547" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="80" dur="0.53s" begin="3.80s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="690" y="556" font-size="12" opacity="0.95" font-weight="700">4</text>
+    <text x="320" y="574" font-size="12" opacity="0.9">.github/releases</text>
+    <rect x="600" y="565" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="60" dur="0.52s" begin="3.90s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="670" y="574" font-size="12" opacity="0.95" font-weight="700">3</text>
+    <text x="320" y="592" font-size="12" opacity="0.9">versions.yml</text>
+    <rect x="600" y="583" width="0" height="10" fill="#FFFFFF" opacity="0.5"><animate attributeName="width" from="0" to="20" dur="0.51s" begin="4.00s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="630" y="592" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="320" y="610" font-size="12" opacity="0.55">other</text>
+    <rect x="600" y="601" width="120" height="10" fill="#FFFFFF" opacity="0.3"/>
+    <text x="730" y="610" font-size="12" opacity="0.7" font-weight="700">6</text>
+
+    <text x="320" y="612" font-size="10" opacity="0.55">+11,944 insertions · -8,420 deletions · Δ ratio 1:1 </text>
+  </g>
+
+  <!-- B5 HEAD: repo state -->
+  <g opacity="0" font-family="ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">REPO @ v0.15.0</text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#FFFFFF" opacity="0.25"/>
+
+    <text x="18" y="466" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700">31</tspan>  docs test harnesses</text>
+    <text x="18" y="486" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700"> 8</tspan>  recipes</text>
+    <text x="18" y="506" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700"> 2</tspan>  migration tests</text>
+    <text x="18" y="526" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700">56</tspan>  CI workflows</text>
+    <text x="18" y="546" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700"> 6</tspan>  Claude skills</text>
+    <text x="18" y="566" font-size="13" opacity="0.95"><tspan fill="#E6007A" font-weight="700"> 7</tspan>  Rust crates</text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 65b352c</text>
+  </g>
+</svg>

--- a/.github/releases/v0.15.0/manifest.yml
+++ b/.github/releases/v0.15.0/manifest.yml
@@ -1,0 +1,8 @@
+release: v0.15.0
+previous_release: v0.14.0
+release_date: 2026-04-16T03:38:30Z
+status: alpha
+
+tooling:
+  rust: "1.91.0"
+  node: "v24.7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-04-16
+
+### Added
+- Complete brand system at `.github/brand/` (tokens, DESIGN.md, ARCHITECTURE.md, voice.md, CHANGELOG.md, scripts) with strict 3-color palette derived from original Polkadot brand (`#E6007A` / `#000000` / `#FFFFFF`)
+- `/branding` skill (`.claude/skills/branding/`) generates 15 SVGs + 2 PNGs in dark + light modes from one source of truth
+- README hero + divider + CONTRIBUTING hero now generated; social-preview + OG image (1200×630) with rasterized PNGs
+- Pathway banners (Pallets / Contracts / Transactions / XCM / Networks) fact-bound to live `recipes/*` counts
+- Favicon at `docs/favicon.svg`
+- Issue templates (`bug.yml`, `recipe-request.yml`, `docs.yml`) + PR template with required Test Plan checklist
+- Brand Lint CI workflow: palette lint, release-cover-palette verify, drift check, a11y check, CHANGELOG-tokens guard
+- Brand Regenerate CI workflow: auto-PR on master token changes
+- `/release --dry-run` mode previews every artifact in a scratch dir without git or GitHub mutations
+- Chain-state footer cover (`cover-chain.svg`) captured via JSON-RPC at release-cut time
+- Template-driven, fact-bound cover art in the release skill
+- Test harness for **Transfer Assets Across Parachains** polkadot-docs guide
+- `TEMPLATE_HEADER_END` sentinel convention for unambiguous template-doc-header stripping
+- `/release` argument-hint for `--dry-run`
+- Frontmatter badge pattern documented in `/add-polkadot-docs-test` skill
+
+### Changed
+- Release skill cover templates (`cover.svg.template`, `cover-chain.svg.template`) migrated to strict pink/black/white palette; fix-commit bars differentiated by opacity, not a secondary hue
+- polkadot-api harnesses pinned to v2.0.1 with refactored imports
+- `run-a-parachain-network` workflow now wires `polkadot_sdk` version from `versions.yml`
+
 ## [0.14.0] - 2026-04-13
 
 ### Added
@@ -43,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Source URLs after upstream docs restructured periphery page
 - CI cache key to reference `docs.test.ts` after test file rename
 
-[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.12.0...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["dot/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Polkadot Cookbook Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
<div align="center">
  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/a293b3b/.github/releases/v0.15.0/cover.svg" alt="Release v0.15.0" width="100%" />
</div>

## Release v0.15.0 · MINOR bump

10 commits · 1 contributors · +11,944 / -8,420 lines · 91 files changed · `v0.14.0` → `v0.15.0`

## Summary

v0.15.0 delivers a complete brand system refactor: every visual surface — README hero, dividers, social preview, OG image, per-pathway banners, CONTRIBUTING hero, favicon, and the release skill's cover art — now derives from a strict 3-color Polkadot palette (#E6007A pink, black, white) via tokens in `.github/brand/`, with CI-enforced palette discipline, drift prevention, and a11y checks. Also ships the `/release --dry-run` mode, a new chain-state footer cover pulled live via JSON-RPC at release-cut time, and one new polkadot-docs test harness (Transfer Assets Across Parachains).

## What's New

- **Brand System** — 1 commit
- **Release Skill** — 5 commits
- **Documentation Tests** — 1 commit
- **Dependencies** — 1 commit
- **CI / Infrastructure** — 1 commit
- **Documentation** — 1 commit



## Test plan

- [ ] `cargo fmt --check --package sdk` passes
- [ ] `cargo clippy --package sdk --locked -- -D warnings` passes
- [ ] `cargo build --workspace --locked` succeeds
- [ ] `cargo test --package sdk --lib --locked -- --test-threads=1` passes
- [ ] `CHANGELOG.md` updated with this release's entries
- [ ] `Cargo.toml` workspace version bumped to `0.15.0`
- [ ] `.github/releases/v0.15.0/RELEASE_NOTES.md` reviewed and looks right
- [ ] `.github/releases/v0.15.0/cover.svg` renders correctly (check in browser — xmllint alone doesn't prove it renders)
- [ ] `.github/releases/v0.15.0/cover-chain.svg` renders correctly (skip check-off if the chain-RPC was unreachable and the footer cover was omitted)

## Next Steps

Merging this PR triggers [`publish-release.yml`](../blob/master/.github/workflows/publish-release.yml), which:
1. Creates the `v0.15.0` git tag
2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
3. Publishes the GitHub Release with cover art, manifest, and binaries attached
