### PR TITLE
chore(paraspell): bump to v13.2.2 and align transfer-assets-parachains with upstream

### DIFF
--- a/polkadot-docs/chain-interactions/transfer-assets-parachains/package-lock.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-parachains/package-lock.json
@@ -8,10 +8,10 @@
       "name": "transfer-assets-parachains",
       "version": "1.0.0",
       "dependencies": {
-        "@paraspell/sdk": "^12.8.8",
+        "@paraspell/sdk": "^13.2.2",
         "@polkadot-labs/hdkd": "^0.0.27",
         "@polkadot-labs/hdkd-helpers": "^0.0.28",
-        "polkadot-api": "^1.23.3"
+        "polkadot-api": "^2.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.12.0",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -69,14 +69,15 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -85,14 +86,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -101,14 +103,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -117,14 +120,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -133,14 +137,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -149,14 +154,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -165,14 +171,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -181,14 +188,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -197,14 +205,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -213,14 +222,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -229,14 +239,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -245,14 +256,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -261,14 +273,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -277,14 +290,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -293,14 +307,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -309,14 +324,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -325,14 +341,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -341,14 +358,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -357,14 +375,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -373,14 +392,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -389,14 +409,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -405,14 +426,15 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -421,14 +443,15 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -437,14 +460,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -453,14 +477,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -469,44 +494,17 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
@@ -548,61 +546,60 @@
       }
     },
     "node_modules/@paraspell/assets": {
-      "version": "12.9.7",
-      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-12.9.7.tgz",
-      "integrity": "sha512-6kRHUV6cNGP7Zwc6mGsgCe9sbmXS+fYrxGoSiKSuHK7JPCD7xurzjs0cNargxpuoNntT+QkoHyAGqxxNWCsI2A==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.2.2.tgz",
+      "integrity": "sha512-UzuudA5IIbzWTwyCtaVZIP7LbeYppW/F2pmC9yAvWcd+YG6jIvh0dEFPzxfsy2HRtgW0fmywH1SghhJghkhZsA==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "12.9.7"
+        "@paraspell/sdk-common": "13.2.2"
       }
     },
     "node_modules/@paraspell/pallets": {
-      "version": "12.9.7",
-      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-12.9.7.tgz",
-      "integrity": "sha512-2NnX3ovMu4AyTSKDZt9TAGPXyf1S4nQif/aOggdtqX0EgA65yfoL7D+CmKhOD2IXbOwpTO46HdzvsjR4RI0ARA==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.2.2.tgz",
+      "integrity": "sha512-2tJaW8z1K7EtW+5Qo/GryAGlddISFlgPRPdLgmwUwh6y0WOn4an9mTzTLsR08fXnIjCKvAiqWYgr+tn/58DrfA==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "12.9.7"
+        "@paraspell/sdk-common": "13.2.2"
       }
     },
     "node_modules/@paraspell/sdk": {
-      "version": "12.9.7",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk/-/sdk-12.9.7.tgz",
-      "integrity": "sha512-SWqovQj60THOfWTT9jhZVED468LosNDzH3evN2AVqHtl1NdO12sjtdM1/nOgNSG/tmQ8DlqlqSvBO/QAMUf8SQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk/-/sdk-13.2.2.tgz",
+      "integrity": "sha512-LqkaFmQXoMCVuVRzrKyQalPO281eiWq3CDwa99FWYjvvtoXz2cnoH6/J9+RwaatJzD1ZTOBaGpHtlFNLY/IiWg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
-        "@paraspell/sdk-core": "12.9.7",
-        "@polkadot-api/legacy-provider": "^0.3.8",
+        "@paraspell/sdk-core": "13.2.2",
         "@polkadot-labs/hdkd": "^0.0.27",
         "@polkadot-labs/hdkd-helpers": "^0.0.28",
-        "viem": "2.47.1"
+        "viem": "^2.47.6"
       },
       "peerDependencies": {
-        "polkadot-api": ">= 1.23.3 < 2"
+        "polkadot-api": ">= 2 < 3"
       }
     },
     "node_modules/@paraspell/sdk-common": {
-      "version": "12.9.7",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-12.9.7.tgz",
-      "integrity": "sha512-ginQjHt6KY6UAnoFoIedhXiBhbHmQWNWTB1Vof4bk/3dakGDjHPUnnhe1MdsWPj1AklloV3H5/zTZ7n2lPIQgw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.2.2.tgz",
+      "integrity": "sha512-7t5lnLPxZWO5Ymso1pi3R5cJkerxr5mqHeBPg+eIADHCsVMhfwQQxbZusxurhNAYc5TnOsEsX2w5btzTnmrPsg==",
       "license": "MIT"
     },
     "node_modules/@paraspell/sdk-core": {
-      "version": "12.9.7",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-12.9.7.tgz",
-      "integrity": "sha512-8nxrif0QofxRtk2uZgJmsiAJXkUbeYj21o6PYcChnvyJds2kIG1RnVnUe19uX9x2ytiqtWKh01hkZvJ4PPwYWQ==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.2.2.tgz",
+      "integrity": "sha512-CFg32x0G6Bg3R9XdDZriWATC4tYob2nGLPw4mMaBc+CgtQ5xBxEqPZiNPF7PIwIVN52yUxU3pq8bSdPHWbx2Yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
-        "@paraspell/assets": "12.9.7",
-        "@paraspell/pallets": "12.9.7",
-        "@paraspell/sdk-common": "12.9.7",
+        "@paraspell/assets": "13.2.2",
+        "@paraspell/pallets": "13.2.2",
+        "@paraspell/sdk-common": "13.2.2",
         "@scure/base": "^2.0.0",
-        "viem": "2.47.1"
+        "viem": "^2.47.6"
       },
       "peerDependencies": {
-        "@paraspell/swap": "^12.0.0"
+        "@paraspell/swap": "^13.0.0"
       },
       "peerDependenciesMeta": {
         "@paraspell/swap": {
@@ -611,42 +608,42 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.18.1.tgz",
-      "integrity": "sha512-jPa8WSNPZWdy372sBAUnm0nU1XX5mLbmgkOOU39+zpYPSE12mYXyM3r7JuT5IHdAccEJr6qK2DplPFTeNSyq9A==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.3.tgz",
+      "integrity": "sha512-aEvUuw9Fd+syt430hJjO8q04QNWmuqlOMbD9WZwLdeMAiGR0+F5h/CUF4tSybiNcbL5jDWLTzrraL5qdSfjm3w==",
       "license": "MIT",
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.21.2",
-        "@polkadot-api/ink-contracts": "0.4.6",
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/known-chains": "0.9.18",
-        "@polkadot-api/legacy-provider": "0.3.8",
-        "@polkadot-api/metadata-compatibility": "0.4.4",
-        "@polkadot-api/observable-client": "0.17.3",
-        "@polkadot-api/polkadot-sdk-compat": "2.4.1",
-        "@polkadot-api/sm-provider": "0.1.16",
-        "@polkadot-api/smoldot": "0.3.15",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/substrate-client": "0.5.0",
-        "@polkadot-api/utils": "0.2.0",
+        "@polkadot-api/codegen": "0.22.3",
+        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/known-chains": "0.11.2",
+        "@polkadot-api/metadata-compatibility": "0.6.1",
+        "@polkadot-api/observable-client": "0.18.4",
+        "@polkadot-api/sm-provider": "0.3.0",
+        "@polkadot-api/smoldot": "0.4.0",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-client": "0.7.0",
+        "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-provider": "0.7.5",
-        "@types/node": "^25.0.10",
-        "commander": "^14.0.2",
+        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-provider": "0.9.0",
+        "@types/node": "^25.6.0",
+        "commander": "^14.0.3",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.1.0",
-        "read-pkg": "^10.0.0",
+        "ora": "^9.3.0",
+        "read-pkg": "^10.1.0",
+        "rollup": "^4.60.1",
+        "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "tsup": "8.5.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "write-package": "^7.2.0"
       },
       "bin": {
-        "papi": "dist/main.js",
-        "polkadot-api": "dist/main.js"
+        "papi": "dist/main/src/main.js",
+        "polkadot-api": "dist/main/src/main.js"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
@@ -658,6 +655,19 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@polkadot-api/cli/node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -665,137 +675,113 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.21.2.tgz",
-      "integrity": "sha512-e1Of2TfB13YndPQ71WrtOIPfRrSlkG6wGprP8/VHC484kkt2JPDOY+io3NdPWkafDblDQ47aG0368sxT+4RSZA==",
+      "version": "0.22.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
+      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.4.6",
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/metadata-compatibility": "0.4.4",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-compatibility": "0.6.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.4.6.tgz",
-      "integrity": "sha512-wpFPa8CnGnmq+cFYMzuTEDmtt3ElBM0UWgTz4RpmI9E7knZ1ctWBhO7amXxOWcILqIG6sqWIE95x0cfF1PRcQg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
+      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/json-rpc-provider": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.4.tgz",
-      "integrity": "sha512-9cDijLIxzHOBuq6yHqpqjJ9jBmXrctjc1OFqU+tQrS96adQze3mTIH6DTgfb/0LMrqxzxffz1HQGrIlEH00WrA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.2.0.tgz",
+      "integrity": "sha512-lhkuBS/x06i3djQIN7p8jVkMnYuGsUAEMS6RhdWeEpz7X/8/APER4Wdih7MEBovCuwVSCTjOxl8f+alH7AZHZg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/json-rpc-provider-proxy": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.2.8.tgz",
-      "integrity": "sha512-AC5KK4p2IamAQuqR0S3YaiiUDRB2r1pWNrdF0Mntm5XGYEmeiAILBmnFa7gyWwemhkTWPYrK5HCurlGfw2EsDA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.4.0.tgz",
+      "integrity": "sha512-h+ay62wwj4y+PJ/JiZ8o54il9UYsgBxq1dxas8mN1Ybth1QxxYPxWvkhyswBNQuWBZIWJw5p3X9cGQku+LvaWQ==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.9.18.tgz",
-      "integrity": "sha512-zdU4FA01lXcpNXUiFgSmFKIwDKbTw15KT4U6Zlqo6FPUMZgncVEbbS4dSgVrf+TGw9SDOUjGlEdyTHAiOAG5Tw==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.2.tgz",
+      "integrity": "sha512-AlOpIbKLcilTf87/unNuZaNQG6IFr9QrP3i7p9SCU1LO8DqVkkWGlQ5CWqnxci1NAXLeRKlSO9M2E/UZVTxdBg==",
       "license": "MIT"
     },
-    "node_modules/@polkadot-api/legacy-provider": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/legacy-provider/-/legacy-provider-0.3.8.tgz",
-      "integrity": "sha512-Q747MN/7IUxxXGLWLQfhmSLqFyOLUsUFqQQytlEBjt66ZAv9VwYiHZ8JMBCnMzFuaUpKEWDT62ESKhgXn/hmEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/raw-client": "0.1.1",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
-      },
-      "peerDependencies": {
-        "rxjs": ">=7.8.0"
-      }
-    },
     "node_modules/@polkadot-api/logs-provider": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/logs-provider/-/logs-provider-0.0.6.tgz",
-      "integrity": "sha512-4WgHlvy+xee1ADaaVf6+MlK/+jGMtsMgAzvbQOJZnP4PfQuagoTqaeayk8HYKxXGphogLlPbD06tANxcb+nvAg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/logs-provider/-/logs-provider-0.2.0.tgz",
+      "integrity": "sha512-BH9YdxZu+ZBPPAUwGrvqHPn1hQStL2Im3MmTwYkwXOWW2HlGHULcF65QKvyK+T6/mj2vDvl3MgivnGkUw4pVxg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4"
+        "@polkadot-api/json-rpc-provider": "0.2.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.1.29.tgz",
-      "integrity": "sha512-z8ivYDdr4xlh50MQ7hLaSVw4VM6EV7gGgd+v/ej09nue0W08NG77zf7pXWeRKgOXe3+hPOSQQRSZT2OlIYRfqA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
+      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.13.9.tgz",
-      "integrity": "sha512-V2GljT6StuK40pfmO5l53CvgFNgy60Trrv20mOZDCsFU9J82F+a1HYAABDYlRgoZ9d0IDwc+u+vI+RHUJoR4xw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
+      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.4.4.tgz",
-      "integrity": "sha512-V4ye5d2ns32YC45Fdc/IF9Y7CgM8inzJbmHQ2DCPSNd6omTRLJd81gU9zU88QAqPAcH2gKGnS5UF+wLL2VagSQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
+      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/substrate-bindings": "0.17.0"
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/substrate-bindings": "0.20.1"
       }
     },
     "node_modules/@polkadot-api/observable-client": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.17.3.tgz",
-      "integrity": "sha512-SJhbMKBIzxNgUUy7ZWflYf/TX9soMqiR2WYyggA7U3DLhgdx4wzFjOSbxCk8RuX9Kf/AmJE4dfleu9HBSCZv6g==",
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
+      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/substrate-client": "0.5.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-client": "0.7.0",
+        "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
         "rxjs": ">=7.8.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.6.19.tgz",
-      "integrity": "sha512-jTHKoanZg9ewupthOczWNb2pici+GK+TBQmp9MwhwGs/3uMD2144aA8VNNBEi8rMxOBZlvKYfGkgjiTEGbBwuQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
+      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
+        "@polkadot-api/metadata-builders": "0.14.1",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.1.20",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
-      }
-    },
-    "node_modules/@polkadot-api/polkadot-sdk-compat": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/polkadot-sdk-compat/-/polkadot-sdk-compat-2.4.1.tgz",
-      "integrity": "sha512-+sET0N3GpnKkLvsazBZEC5vhqAlamlL1KkJK9STB1tRxHSZcY/yBBa1Udn9DXJfX48kE9cnzfYldl9zsjqpARg==",
-      "license": "MIT",
-      "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4"
+        "@polkadot-api/signers-common": "0.2.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/polkadot-signer": {
@@ -805,105 +791,115 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/raw-client": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/raw-client/-/raw-client-0.1.1.tgz",
-      "integrity": "sha512-HxalpNEo8JCYXfxKM5p3TrK8sEasTGMkGjBNLzD4TLye9IK2smdb5oTvp2yfkU1iuVBdmjr69uif4NaukOYo2g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/raw-client/-/raw-client-0.3.0.tgz",
+      "integrity": "sha512-u/wM9W7ugIXxBSOEV8+zvQI43b5vgSI0pvE0Rg8PV0G65BTLK0SMc2o2SQL0HtS5+bi5sw/gg4reBJ/0a4U0cw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4"
+        "@polkadot-api/json-rpc-provider": "0.2.0"
       }
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.2.13.tgz",
-      "integrity": "sha512-XBOtjFsRGETVm/aXeZnsvFcJ1qvtZhRtwUMmpCOBt9s8PWfILaQH/ecOegzda3utNIZGmXXaOoJ5w9Hc/6I3ww==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
+      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.0.1",
-        "@polkadot-api/merkleize-metadata": "1.1.29",
+        "@noble/hashes": "^2.2.0",
+        "@polkadot-api/merkleize-metadata": "1.2.1",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.1.20",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/signers-common": "0.2.1",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.1.20.tgz",
-      "integrity": "sha512-v1mrTdRjQOV17riZ8172OsOQ/RJbv1QsEpjwnvxzvdCnjuNpYwtYHZaE+cSdDBb4n1p73XIBMvB/uAK/QFC2JA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
+      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.13.9",
+        "@polkadot-api/metadata-builders": "0.14.1",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.1.16.tgz",
-      "integrity": "sha512-3LEDU7nkgtDx1A6ATHLLm3+nFAY6cdkNA9tGltfDzW0efACrhhfDjNqJdI1qLNY0wDyT1aGdoWr5r+4CckRpXA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
+      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/json-rpc-provider-proxy": "0.2.8"
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/json-rpc-provider-proxy": "0.4.0"
       },
       "peerDependencies": {
         "@polkadot-api/smoldot": ">=0.3"
       }
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.3.15.tgz",
-      "integrity": "sha512-YyV+ytP8FcmKEgLRV7uXepJ5Y6md/7u2F8HKxmkWytmnGXO1z+umg2pHbOxLGifD9V2NhkPY+awpzErtVIzqAA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
+      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^24.10.1",
+        "@polkadot-api/smoldot-patch": "102.0.0",
+        "@types/node": "^25.5.0",
         "smoldot": "2.0.40"
       }
     },
+    "node_modules/@polkadot-api/smoldot-patch": {
+      "version": "102.0.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
+      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "dependencies": {
+        "ws": "^8.8.1"
+      }
+    },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.17.0.tgz",
-      "integrity": "sha512-YdbkvG/27N5A94AiKE4soVjDy0Nw74Nn+KD29mUnFmIZvL3fsN/DTYkxvMDVsOuanFXyAIXmzDMoi7iky0fyIw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
+      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.0.1",
-        "@polkadot-api/utils": "0.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@polkadot-api/utils": "0.4.0",
         "@scure/base": "^2.0.0",
         "scale-ts": "^1.6.1"
       }
     },
     "node_modules/@polkadot-api/substrate-client": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.5.0.tgz",
-      "integrity": "sha512-J+gyZONCak+n6NxADZWtldH+gatYORqEScMAgI9gGu43pHUe7/xNRCqnin0dgDIzmuL3m1ERglF8LR7YhB0nHQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.7.0.tgz",
+      "integrity": "sha512-TWCc4MAMa5SLVQXmomLHknbj+bztQ/Yclgwm8ENBhz8hR7c9rw9FBAkCa02jMBMCAygPhp3ayGRq+UFcF8KIxQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/raw-client": "0.1.1",
-        "@polkadot-api/utils": "0.2.0"
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/raw-client": "0.3.0",
+        "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.2.0.tgz",
-      "integrity": "sha512-nY3i5fQJoAxU4n3bD7Fs208/KR2J95SGfVc58kDjbRYN5a84kWaGEqzjBNtP9oqht49POM8Bm9mbIrkvC1Bzuw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-9b/hwRM0UloLWV7SfpNaSD/4k8UQAHoaACAk7Xe+1MlfAm2JtnmPiB1GfGrfTyBlsrJVUIBCZpEmbmxVMaIqBA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/wasm-executor": {
@@ -912,16 +908,34 @@
       "integrity": "sha512-B2h1o+Qlo9idpASaHvMSoViB2I5ko5OAfwfhYF8LQDkTADK0B+SeStzNj1Qn+FG34wqTuv7HzBCdjaUgzYINJQ==",
       "license": "MIT"
     },
-    "node_modules/@polkadot-api/ws-provider": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-provider/-/ws-provider-0.7.5.tgz",
-      "integrity": "sha512-2ZLEo0PAFeuOx2DUDkbex85HZMf9lgnmZ8oGB5+NaButIydkoqXy5SHYJNPc45GcZy2tvwzImMZInNMLa5GJhg==",
+    "node_modules/@polkadot-api/ws-middleware": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.2.tgz",
+      "integrity": "sha512-x3WuA59NrcIbhfFw+LRnlDNRdMRdg9Wz8OCK6HUjjwFfL/O+yNtf/pTGuINuOigZzmBj7hHixPaVw9VJogCN6Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/json-rpc-provider-proxy": "0.2.8",
-        "@types/ws": "^8.18.1",
-        "ws": "^8.19.0"
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
+        "@polkadot-api/raw-client": "0.3.0",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/utils": "0.4.0"
+      },
+      "peerDependencies": {
+        "rxjs": ">=7.8.0"
+      }
+    },
+    "node_modules/@polkadot-api/ws-provider": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-provider/-/ws-provider-0.9.0.tgz",
+      "integrity": "sha512-czTLgHEJPqx+6t5sb5OJpXDaSmbDTr8zYngBdUI47QYqcNB225zo/GdYakiNiGThtxVp1MLK7QsNXcT6XgqQNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
+        "@polkadot-api/utils": "0.4.0"
+      },
+      "peerDependencies": {
+        "rxjs": ">=7.8.0"
       }
     },
     "node_modules/@polkadot-labs/hdkd": {
@@ -1444,6 +1458,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1454,15 +1469,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1612,18 +1618,6 @@
         }
       }
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1636,12 +1630,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1652,25 +1640,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/bundle-require": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
-      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
-      "license": "MIT",
-      "dependencies": {
-        "load-tsconfig": "^0.2.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.18"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1715,21 +1689,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -1764,21 +1723,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "license": "MIT"
-    },
-    "node_modules/consola": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1847,15 +1791,15 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1863,32 +1807,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/estree-walker": {
@@ -1943,23 +1887,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -1973,17 +1900,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/fix-dts-default-cjs-exports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
-      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.17",
-        "mlly": "^1.7.4",
-        "rollup": "^4.34.8"
       }
     },
     "node_modules/fs.promises.exists": {
@@ -2035,6 +1951,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/hosted-git-info": {
@@ -2148,52 +2076,10 @@
         "ws": "*"
       }
     },
-    "node_modules/joycon": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
-    },
-    "node_modules/load-tsconfig": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
-      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -2232,6 +2118,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2249,40 +2136,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2339,15 +2203,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -2386,9 +2241,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
-      "integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
+      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
       "funding": [
         {
           "type": "github",
@@ -2526,55 +2381,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
     "node_modules/polkadot-api": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-1.23.3.tgz",
-      "integrity": "sha512-wOWli6Cfk3bO1u/W8qmwriCIKxATkNea8Jyg1jj7GzAqafxy295BYPzYHy2mJZCQ0PAVFPR4/JvCXocTLBsp5A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.2.tgz",
+      "integrity": "sha512-eYj7VUVuZu4CibGnhJGfixqiGc5IIiJX87fNpW+UVvqht3DxVBWpPpUCDwP6AH4lKY97zgNfp4o18HMgp9aV2Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.18.1",
-        "@polkadot-api/ink-contracts": "0.4.6",
-        "@polkadot-api/json-rpc-provider": "0.0.4",
-        "@polkadot-api/known-chains": "0.9.18",
-        "@polkadot-api/logs-provider": "0.0.6",
-        "@polkadot-api/metadata-builders": "0.13.9",
-        "@polkadot-api/metadata-compatibility": "0.4.4",
-        "@polkadot-api/observable-client": "0.17.3",
-        "@polkadot-api/pjs-signer": "0.6.19",
-        "@polkadot-api/polkadot-sdk-compat": "2.4.1",
+        "@polkadot-api/cli": "0.20.3",
+        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/json-rpc-provider": "0.2.0",
+        "@polkadot-api/known-chains": "0.11.2",
+        "@polkadot-api/logs-provider": "0.2.0",
+        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-compatibility": "0.6.1",
+        "@polkadot-api/observable-client": "0.18.4",
+        "@polkadot-api/pjs-signer": "0.7.1",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.2.13",
-        "@polkadot-api/sm-provider": "0.1.16",
-        "@polkadot-api/smoldot": "0.3.15",
-        "@polkadot-api/substrate-bindings": "0.17.0",
-        "@polkadot-api/substrate-client": "0.5.0",
-        "@polkadot-api/utils": "0.2.0",
-        "@polkadot-api/ws-provider": "0.7.5",
+        "@polkadot-api/signer": "0.3.1",
+        "@polkadot-api/sm-provider": "0.3.0",
+        "@polkadot-api/smoldot": "0.4.0",
+        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-client": "0.7.0",
+        "@polkadot-api/utils": "0.4.0",
+        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
       "bin": {
-        "papi": "bin/cli.mjs",
-        "polkadot-api": "bin/cli.mjs"
+        "papi": "bin/cli.js",
+        "polkadot-api": "bin/cli.js"
       },
       "peerDependencies": {
         "rxjs": ">=7.8.0"
@@ -2584,7 +2419,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2609,48 +2444,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -2664,15 +2457,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/read-pkg": {
@@ -2706,26 +2490,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
       "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/restore-cursor": {
@@ -2786,6 +2557,25 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-esbuild": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-6.2.1.tgz",
+      "integrity": "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "get-tsconfig": "^4.10.0",
+        "unplugin-utils": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18.0",
+        "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/rxjs": {
@@ -2879,24 +2669,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "deprecated": "The work that was done in this beta branch won't be included in future versions",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -3003,37 +2780,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -3044,27 +2790,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -3078,23 +2803,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
@@ -3126,30 +2836,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/tsc-prog": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tsc-prog/-/tsc-prog-2.3.0.tgz",
@@ -3167,58 +2853,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsup": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
-      "integrity": "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-require": "^5.1.0",
-        "cac": "^6.7.14",
-        "chokidar": "^4.0.3",
-        "consola": "^3.4.0",
-        "debug": "^4.4.0",
-        "esbuild": "^0.25.0",
-        "fix-dts-default-cjs-exports": "^1.0.0",
-        "joycon": "^3.1.1",
-        "picocolors": "^1.1.1",
-        "postcss-load-config": "^6.0.1",
-        "resolve-from": "^5.0.0",
-        "rollup": "^4.34.8",
-        "source-map": "0.8.0-beta.0",
-        "sucrase": "^3.35.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.11",
-        "tree-kill": "^1.2.2"
-      },
-      "bin": {
-        "tsup": "dist/cli-default.js",
-        "tsup-node": "dist/cli-node.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@microsoft/api-extractor": "^7.36.0",
-        "@swc/core": "^1",
-        "postcss": "^8.4.12",
-        "typescript": ">=4.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@microsoft/api-extractor": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/type-fest": {
       "version": "5.5.0",
@@ -3248,16 +2882,11 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -3272,6 +2901,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unplugin-utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+      "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -3283,9 +2928,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.1",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.1.tgz",
-      "integrity": "sha512-frlK109+X5z2vlZeIGKa6Rxev6CcIpumV/VVhaIPc/QFotiB6t/CgUwkMlYfr4F2YNBZZ2l6jguWz2sY1XrQHw==",
+      "version": "2.48.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.0.tgz",
+      "integrity": "sha512-0uLzTAUNKPpY9Cf3OBCPdwClXx9CEHAkoVYnxMPdHt7cRI1DobMso+pHZvU7itD+hFwE4htmp9QfP+5lb+kn0g==",
       "funding": [
         {
           "type": "github",
@@ -3300,7 +2945,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.0",
+        "ox": "0.14.17",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -3952,23 +3597,6 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/polkadot-docs/chain-interactions/transfer-assets-parachains/package.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-parachains/package.json
@@ -7,10 +7,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@paraspell/sdk": "^12.8.8",
+    "@paraspell/sdk": "^13.2.2",
     "@polkadot-labs/hdkd": "^0.0.27",
     "@polkadot-labs/hdkd-helpers": "^0.0.28",
-    "polkadot-api": "^1.23.3"
+    "polkadot-api": "^2.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/polkadot-docs/chain-interactions/transfer-assets-parachains/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/transfer-assets-parachains/tests/docs.test.ts
@@ -41,7 +41,7 @@ function buildBase() {
     .from("AssetHubPaseo")
     .to("PeoplePaseo")
     .currency({ symbol: "PAS", amount: AMOUNT })
-    .address(recipientAddress);
+    .recipient(recipientAddress);
 }
 
 // ---------------------------------------------------------------------------
@@ -50,7 +50,7 @@ function buildBase() {
 
 describe("1. ParaSpell — Build Transfer Transaction", () => {
   it("should build an XCM transfer from AssetHubPaseo to PeoplePaseo", async () => {
-    const tx = await buildBase().senderAddress(senderAddress).build();
+    const tx = await buildBase().sender(senderAddress).build();
     expect(tx).toBeDefined();
     console.log("ParaSpell: Transaction built");
   });
@@ -67,7 +67,7 @@ describe("2. ParaSpell — Dry Run Transfer", () => {
       return;
     }
 
-    const result = await buildBase().senderAddress(senderAddress).dryRun();
+    const result = await buildBase().sender(senderAddress).dryRun();
     console.log("ParaSpell dry run result:", result);
     expect(result).toBeDefined();
   });
@@ -80,7 +80,7 @@ describe("2. ParaSpell — Dry Run Transfer", () => {
 describe("3. ParaSpell — Verify Existential Deposit", () => {
   it("should check ED requirement on destination", async () => {
     const isValid = await buildBase()
-      .senderAddress(senderAddress)
+      .sender(senderAddress)
       .verifyEdOnDestination();
     console.log(`ParaSpell: ED verification ${isValid ? "passed" : "failed"}.`);
     expect(typeof isValid).toBe("boolean");
@@ -94,7 +94,7 @@ describe("3. ParaSpell — Verify Existential Deposit", () => {
 describe("4. ParaSpell — Get Transfer Info", () => {
   it("should return fee estimates and balance info", async () => {
     const info = await buildBase()
-      .senderAddress(senderAddress)
+      .sender(senderAddress)
       .getTransferInfo();
     console.log("ParaSpell transfer info:", info);
     expect(info).toBeDefined();

--- a/versions.yml
+++ b/versions.yml
@@ -70,7 +70,7 @@ javascript_packages:
     version: "1.2.8"
   paraspell_sdk:
     name: "@paraspell/sdk"
-    version: "12.8.8"
+    version: "13.2.2"
   hdkd:
     name: "@polkadot-labs/hdkd"
     version: "0.0.27"


### PR DESCRIPTION
## Summary

- Bump `javascript_packages.paraspell_sdk` in `versions.yml` from `12.8.8` → `13.2.2`.
- Mirror upstream v13 API renames in `polkadot-docs/chain-interactions/transfer-assets-parachains`:
  - `.address(...)` → `.recipient(...)`
  - `.senderAddress(...)` → `.sender(...)`
- Move this harness back onto `polkadot-api@^2.0.1` (same as the rest of the cookbook). `@paraspell/sdk@13.2.2` now peer-deps on `polkadot-api >= 2 < 3` (paraspell/xcm-tools#1809), so the v1 pin from 4feec19 is no longer needed.

Runtime-verifies polkadot-developers/polkadot-docs#1639 end-to-end against Paseo Asset Hub → Paseo People Chain; the test suite surfaced a missing `.sender()` in the tutorial's `transfer()` function (`.build()` now calls `computeAllFees` which requires a sender on DOT/Snowbridge-path assets), which is fixed in an upstream commit on the same PR.

## Test plan

- [x] `cd polkadot-docs/chain-interactions/transfer-assets-parachains && npm ci && npm test` → 4 passed, 1 skipped (submit skipped without `SENDER_MNEMONIC`)
- [x] Verify `.address` / `.senderAddress` no longer appear in the harness (only remaining `.address` is `getSignerAndAddress().address` — a property access on the returned object, not the ParaSpell API)
- [x] Confirm `versions.yml` `paraspell_sdk.version` is `13.2.2` and `polkadot-docs/chain-interactions/transfer-assets-parachains/package.json` pins match
- [x] CI workflow `Transfer Assets Between Parachains` goes green (guard SUCCESS, test SUCCESS)