### PR TITLE
chore(release-skill): resolve branch commit vs. commit-msg hook conflict

### DIFF
--- a/.claude/skills/release/COMMIT_CONVENTIONS.md
+++ b/.claude/skills/release/COMMIT_CONVENTIONS.md
@@ -12,11 +12,15 @@ Branched from `master`. Deleted on merge.
 
 ## Release commit (on the release branch)
 
-**Subject:** `Release v{VERSION}`
+**Subject on the branch:** `chore(release): v{VERSION}` — required to pass the repo's `commit-msg` hook (`.cargo-husky/hooks/commit-msg`), which enforces conventional-commit prefixes and explicitly exempts `chore(release)`. `Release v{VERSION}` is not a conventional-commit type and will be rejected.
+
+**PR title (and therefore squash-merge subject on `master`):** `Release v{VERSION}`
 
 **Body (optional):** Empty; all narrative lives in `RELEASE_NOTES.md`.
 
-When the release PR merges (squash merge), GitHub's auto-generated squash-commit subject becomes `Release v{VERSION} (#N)` where `#N` is the PR number. This is desirable — downstream tooling matches the regex `^Release v[0-9]+\.[0-9]+\.[0-9]+ \(#[0-9]+\)$` to identify release commits.
+GitHub derives the squashed commit on `master` from the **PR title**, not the branch commit. So setting the PR title to `Release v{VERSION}` produces the final commit subject `Release v{VERSION} (#N)` on `master` — which is what downstream tooling matches with the regex `^Release v[0-9]+\.[0-9]+\.[0-9]+ \(#[0-9]+\)$`. The `chore(release): v{VERSION}` branch commit is only visible in the PR diff view and is discarded on merge.
+
+Do **not** bypass the hook with `--no-verify`. The two-subject pattern (branch vs. PR title) is intentional — it keeps both the local hook and the downstream tag regex happy without contorting either.
 
 ## Tag
 
@@ -47,4 +51,5 @@ These classifications feed `@@COMMIT_LIST` (cover.svg), `@@COMMIT_TYPES` (cover.
 - Edit an existing release commit (no `--amend`, no force-push to an already-pushed release branch).
 - Create a tag locally — that's `publish-release.yml`'s job.
 - Move or recreate a tag that already exists on the remote (would break immutability guarantees for anyone who already pulled it).
-- Use any commit subject format other than the exact string `Release v{VERSION}`.
+- Use `Release v{VERSION}` as the **branch** commit subject (the `commit-msg` hook rejects it). The string `Release v{VERSION}` belongs on the PR **title**, where GitHub turns it into the squash-merge subject on `master`.
+- Bypass the `commit-msg` hook with `--no-verify` to force `Release v{VERSION}` on the branch.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -302,11 +302,13 @@ python3 .claude/skills/release/render.py manifest \
 
 1. Create a release branch: `git checkout -b release/vX.Y.Z`
 
-2. Stage and commit. The commit subject must match [`COMMIT_CONVENTIONS.md`](COMMIT_CONVENTIONS.md) exactly — `Release v{VERSION}` (capital R, no `chore:` prefix). Downstream tooling matches the regex `^Release v[0-9]+\.[0-9]+\.[0-9]+ \(#[0-9]+\)$` against the squashed commit on `master`:
+2. Stage the artifacts. Downstream tooling matches the regex `^Release v[0-9]+\.[0-9]+\.[0-9]+ \(#[0-9]+\)$` against the **squashed commit on `master`**, which GitHub derives from the **PR title** at merge time — not from the branch commit. The branch commit itself must pass the repo's `commit-msg` hook (`.cargo-husky/hooks/commit-msg`), which rejects `Release vX.Y.Z` because it is not a conventional-commit type. The hook explicitly exempts `chore(release)`:
    ```bash
    git add .github/releases/vX.Y.Z/ Cargo.toml Cargo.lock CHANGELOG.md  # includes cover.svg + cover-chain.svg
-   git commit -m "Release vX.Y.Z"
+   git commit -m "chore(release): vX.Y.Z"
    ```
+
+   Do not use `--no-verify`. Do not use `Release vX.Y.Z` as the branch commit subject — the hook blocks it. Set the **PR title** (step 3) to `Release vX.Y.Z` so the squash-merged commit on `master` satisfies downstream tooling.
 
 3. Push, then render the PR body from [`RELEASE_PR_BODY.template.md`](RELEASE_PR_BODY.template.md) via the renderer. The cover image src uses a **commit-SHA-pinned** raw URL (not the branch name — the branch is deleted on merge and branch-based raw URLs break retroactively). Capture `HEAD_SHA` after the commit lands:
 


### PR DESCRIPTION
## Summary

During the v0.17.0 release cut, Phase 4 step 2 of the release skill hit the repo's `commit-msg` hook:

- `SKILL.md` instructed `git commit -m \"Release vX.Y.Z\"` on the release branch.
- The hook (`.cargo-husky/hooks/commit-msg`) rejects that subject — it enforces conventional-commit prefixes and only exempts `chore(release)`.

The fix exploits the fact that GitHub derives the squash-merge subject on \`master\` from the **PR title**, not the branch commit. So the skill now uses two different subjects:

- **Branch commit:** \`chore(release): vX.Y.Z\` — passes the hook, no \`--no-verify\` required.
- **PR title:** \`Release vX.Y.Z\` — becomes \`Release vX.Y.Z (#N)\` after squash-merge, which matches the downstream regex \`^Release v[0-9]+\\.[0-9]+\\.[0-9]+ \\(#[0-9]+\\)$\` used by \`publish-release.yml\`.

## Changes

- \`SKILL.md\` Phase 4 step 2: branch commit now uses \`chore(release): vX.Y.Z\`; added explicit note that \`Release vX.Y.Z\` belongs on the PR title, not the branch.
- \`COMMIT_CONVENTIONS.md\`: split "Release commit" section into branch subject + PR title; added explicit \"do not\" entries against \`--no-verify\` and against putting \`Release v{VERSION}\` on the branch commit.

## Test plan

- [x] v0.17.0 release PR (#284) used the new two-subject pattern; \`commit-msg\` hook passed without \`--no-verify\`.
- [ ] Next release cut follows the updated SKILL.md without re-discovering the hook conflict.
- [ ] On squash-merge of #284 to master, the resulting commit subject matches \`^Release v[0-9]+\\.[0-9]+\\.[0-9]+ \\(#[0-9]+\\)$\` and \`publish-release.yml\` tags + publishes \`v0.17.0\`.