### PR TITLE
chore(brand): drop misleading 'RECIPES' caption from pathway banner

### DIFF
--- a/.claude/skills/branding/templates/pathway-banner.svg.template
+++ b/.claude/skills/branding/templates/pathway-banner.svg.template
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="{{SURFACE}}"/>
-  <text x="50" y="110" text-anchor="middle" font-family="{{MONO}}" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="{{MONO}}" font-size="40" font-weight="800"
         fill="{{PINK}}" letter-spacing="-2">{{PATHWAY_NUMBER}}</text>
-  <text x="50" y="140" text-anchor="middle" font-family="{{MONO}}" font-size="9" fill="{{FG_DIM}}"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="{{LINE}}"/>
 
   <!-- Col 2: Body -->

--- a/.github/media/pathway-contracts-dark.svg
+++ b/.github/media/pathway-contracts-dark.svg
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="#111114"/>
-  <text x="50" y="110" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
         fill="#E6007A" letter-spacing="-2">02</text>
-  <text x="50" y="140" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="9" fill="#6B6B74"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="#2A2A30"/>
 
   <!-- Col 2: Body -->

--- a/.github/media/pathway-networks-dark.svg
+++ b/.github/media/pathway-networks-dark.svg
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="#111114"/>
-  <text x="50" y="110" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
         fill="#E6007A" letter-spacing="-2">05</text>
-  <text x="50" y="140" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="9" fill="#6B6B74"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="#2A2A30"/>
 
   <!-- Col 2: Body -->

--- a/.github/media/pathway-pallets-dark.svg
+++ b/.github/media/pathway-pallets-dark.svg
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="#111114"/>
-  <text x="50" y="110" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
         fill="#E6007A" letter-spacing="-2">01</text>
-  <text x="50" y="140" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="9" fill="#6B6B74"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="#2A2A30"/>
 
   <!-- Col 2: Body -->

--- a/.github/media/pathway-transactions-dark.svg
+++ b/.github/media/pathway-transactions-dark.svg
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="#111114"/>
-  <text x="50" y="110" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
         fill="#E6007A" letter-spacing="-2">03</text>
-  <text x="50" y="140" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="9" fill="#6B6B74"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="#2A2A30"/>
 
   <!-- Col 2: Body -->

--- a/.github/media/pathway-xcm-dark.svg
+++ b/.github/media/pathway-xcm-dark.svg
@@ -7,10 +7,8 @@
 
   <!-- Col 1: Number -->
   <rect x="0" y="0" width="100" height="200" fill="#111114"/>
-  <text x="50" y="110" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
+  <text x="50" y="115" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="40" font-weight="800"
         fill="#E6007A" letter-spacing="-2">04</text>
-  <text x="50" y="140" text-anchor="middle" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" font-size="9" fill="#6B6B74"
-        letter-spacing="1.5">RECIPES</text>
   <line x1="100" y1="0" x2="100" y2="200" stroke="#2A2A30"/>
 
   <!-- Col 2: Body -->


### PR DESCRIPTION
## Summary

`pathway-banner.svg.template` showed a small "RECIPES" caption directly beneath the big pathway-index number (`01`–`05`). The caption implied the number above it was a recipe count, but it's actually the pathway index. Bonus: the body column right next to it already says `PATHWAY · NN/05`, so the caption was both misleading **and** redundant.

Drop the caption; re-center the number in its column.

## Why

Follow-up from #287 (count removal). Same class of legacy: a label that suggested live data when the value was static.

## Changes

- `templates/pathway-banner.svg.template`: remove the `RECIPES` text element, shift the number's `y` from `110` → `115` to re-center after the caption is gone.
- Regenerated 5 pathway banner SVGs.

Net diff: **6 files, +6 / −18.**

## Test plan

- [x] `bash .claude/skills/branding/generate.sh` runs cleanly.
- [x] `bash .github/brand/scripts/check-drift.sh` passes.
- [x] `bash .github/brand/scripts/check-a11y.sh` passes.
- [ ] CI on this branch — `palette · drift · a11y` job goes green.
- [ ] Eyeball the rendered pathway banners in the PR diff — confirm the number sits visually centered now.