### PR TITLE
Release v0.18.0

### DIFF
--- a/.github/releases/v0.18.0/RELEASE_NOTES.md
+++ b/.github/releases/v0.18.0/RELEASE_NOTES.md
@@ -1,0 +1,67 @@
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.18.0/.github/releases/v0.18.0/cover.svg" alt="Release v0.18.0" width="100%" />
+</div>
+
+# Release v0.18.0
+
+Released: 2026-05-21
+
+## Summary
+
+This release adds two new documentation test harnesses — **Transfer Assets into Polkadot** (XCM) and **Uniswap V3 Periphery with Hardhat** (smart contracts) — extending coverage of the cross-chain and EVM tutorial surface. A new self-healing CI workflow now tracks JavaScript dependency drift in `versions.yml` against an automatically-managed `versions-drift` issue, and several brand templates were tightened to remove misleading captions and live counts.
+
+## What's New
+
+### Documentation Tests
+
+- Added test harness for **Transfer Assets into Polkadot** — verifies the XCM flow that moves assets from a remote consumer parachain into Polkadot, so changes to the guide or upstream SDK can no longer silently break this cross-chain pattern (#288)
+- Added test harness for **Uniswap V3 Periphery with Hardhat** — exercises the full Uniswap V3 deployment pipeline against pallet-revive, ensuring the EVM smart-contract tutorial keeps working as Hardhat and the dev node evolve (#286)
+
+### Infrastructure
+
+- Added a self-healing CI workflow that detects when JavaScript harnesses fall below the `versions.yml` floor and opens/updates a single tracked `versions-drift` issue, eliminating manual auditing of pinned JS versions across dozens of harnesses (#282)
+
+### Tooling
+
+- Resolved a conflict between the release skill's commit step and the local commit-msg hook so future releases no longer require manual intervention to bypass the hook (#285)
+- Removed the misleading `RECIPES` caption from pathway banners — the banners are used by both recipes and polkadot-docs, so the label was inaccurate (#289)
+- Removed live counts from hero, contributing-hero, and pathway banner templates — the numbers drifted between local renders and CI, undermining the apple.com-level polish those surfaces aim for (#287)
+
+## Commits
+
+- feat: add transfer-assets-into-polkadot polkadot-docs test harness (#288)
+- feat: add Uniswap V3 Periphery with Hardhat CI harness (#286)
+- ci: track versions.yml JS drift via self-healing issue (#282)
+- chore(brand): drop misleading 'RECIPES' caption from pathway banner (#289)
+- chore(brand): remove live counts from hero/contributing-hero/pathway templates (#287)
+- chore(release-skill): resolve branch commit vs. commit-msg hook conflict (#285)
+
+## Stats
+
+**6 commits, +6,909 / -7,689 lines**
+
+**Full Changelog:** https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.17.0...v0.18.0
+
+## Compatibility
+
+Tested with:
+- Rust: 1.91.0
+- Node.js: v24.7.0
+
+## Next Steps
+
+Merging the release PR triggers [`publish-release.yml`](../../../.github/workflows/publish-release.yml), which:
+1. Creates the `v0.18.0` git tag
+2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
+3. Publishes the GitHub Release with cover art, manifest, and binaries attached
+
+---
+
+**Status:** Alpha (v0.x.x)
+
+---
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.18.0/.github/releases/v0.18.0/cover-chain.svg" alt="Polkadot network state at v0.18.0 release" width="100%" />
+</div>

--- a/.github/releases/v0.18.0/RELEASE_NOTES.md
+++ b/.github/releases/v0.18.0/RELEASE_NOTES.md
@@ -49,13 +49,6 @@ Tested with:
 - Rust: 1.91.0
 - Node.js: v24.7.0
 
-## Next Steps
-
-Merging the release PR triggers [`publish-release.yml`](../../../.github/workflows/publish-release.yml), which:
-1. Creates the `v0.18.0` git tag
-2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
-3. Publishes the GitHub Release with cover art, manifest, and binaries attached
-
 ---
 
 **Status:** Alpha (v0.x.x)

--- a/.github/releases/v0.18.0/cover-chain.svg
+++ b/.github/releases/v0.18.0/cover-chain.svg
@@ -1,0 +1,247 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  <rect width="1200" height="630" fill="#0A0A0B"/>
+
+  <!-- ========== MONDRIAN GRID + BLOCKS (same geometry as top cover) ========== -->
+
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 RUNTIME TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#0A0A0B"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#F6F5F2" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ polkadot runtime @ block 31,329,361 ├────────┐
+    </text>
+
+    <text x="774" y="46" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.7s" fill="freeze"/>
+      │ spec_name         polkadot
+    </text>
+    <text x="774" y="60" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.9s" fill="freeze"/>
+      │ spec_version      2,002,001
+    </text>
+    <text x="774" y="74" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.1s" fill="freeze"/>
+      │ impl_name         parity-polkadot
+    </text>
+    <text x="774" y="88" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.3s" fill="freeze"/>
+      │ node              1.22.1-f8cfbb96055
+    </text>
+    <text x="774" y="102" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.5s" fill="freeze"/>
+      │ authoring_version 0
+    </text>
+    <text x="774" y="116" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.7s" fill="freeze"/>
+      │ transaction_ver   26
+    </text>
+    <text x="774" y="130" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.9s" fill="freeze"/>
+      │ state_version     1
+    </text>
+    <text x="774" y="144" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="3.1s" fill="freeze"/>
+      │ system_version    1
+    </text>
+    <text x="774" y="158" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0">
+      <animate attributeName="opacity" values="0;0.95" dur="0.15s" begin="3.4s" fill="freeze"/>
+      │ runtime_apis      24 exposed
+    </text>
+
+    <text x="774" y="196" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ state_root  0x9968aecb..  genesis  0x91b171bb..
+    </text>
+    <text x="774" y="210" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ ss58 0 · DOT · 10 decimals · 6s block target
+    </text>
+    <text x="774" y="224" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.55" letter-spacing="0.4">
+      └─ rpc.polkadot.io · peers 88 · synced ✓ ─────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <!-- No tip-pulse animation: this is a point-in-time reading, not a live chain tip -->
+
+  <!-- ========== FACTUAL OVERLAYS ========== -->
+
+  <!-- B1 PINK: headline + release-time disclaimer badge -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <!-- Disclaimer (the ONE place point-in-time nature is stated) -->
+    <g>
+      <rect x="410" y="22" width="318" height="114" fill="#0A0A0B" opacity="0.5" stroke="#F6F5F2" stroke-opacity="0.8" stroke-width="1"/>
+      <text x="432" y="52" font-size="11" font-weight="700" letter-spacing="1.8" opacity="0.98">◆ POINT-IN-TIME READING</text>
+      <text x="432" y="82" font-size="13" font-weight="700" opacity="0.95">polkadot-cookbook v0.18.0</text>
+      <text x="432" y="104" font-size="10" opacity="0.75">captured 2026-05-21 09:27 UTC</text>
+      <text x="432" y="122" font-size="10" opacity="0.6">mainnet state at release — not live</text>
+    </g>
+
+    <!-- Corner tag -->
+    <text x="36" y="34" font-size="10" letter-spacing="1.5" opacity="0.85">[0x91b171bb] GENESIS</text>
+
+    <!-- Headline -->
+    <text x="36" y="156" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">POLKADOT</text>
+    <text x="36" y="180" font-size="11" letter-spacing="2.5" opacity="0.75">
+      MAINNET  ·  rpc.polkadot.io
+    </text>
+
+    <rect x="36" y="204" width="670" height="1" fill="#F6F5F2" opacity="0.35"/>
+
+    <text x="36" y="230" font-size="10" letter-spacing="1.5" opacity="0.65">FINALIZED BLOCK</text>
+    <text x="36" y="278" font-size="48" font-weight="700" letter-spacing="-0.5" opacity="0.95">#31,329,361</text>
+    <text x="36" y="300" font-size="11" opacity="0.55">0x4b88a72a..7d51</text>
+
+    <text x="36" y="340" font-size="10" letter-spacing="1.5" opacity="0.65">NETWORK AGE</text>
+    <text x="36" y="362" font-size="13" opacity="0.9"><tspan fill="#F6F5F2" font-weight="700">~5 years, 12 months</tspan>  <tspan opacity="0.55">since 2020-05-26</tspan></text>
+    <text x="36" y="380" font-size="11" opacity="0.6">block 0 → 31,329,361</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SPEC callout -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">RUNTIME SPEC</text>
+    <text x="772" y="316" font-size="26" font-weight="700" opacity="0.95">2,002,001</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">polkadot runtime</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">tx v26 · state v1</text>
+  </g>
+
+  <!-- Empty cell: ref node health -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">REF NODE HEALTH</text>
+    <text x="946" y="302" font-size="12" opacity="0.85">peers       <tspan fill="#E6007A">████████████</tspan>  82</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">syncing     <tspan fill="#E6007A">✓</tspan>     false</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">authoring   <tspan opacity="0.5">—</tspan>     v0</text>
+    <text x="946" y="368" font-size="10" opacity="0.45">NODE  parity-polkadot 1.22.1-f8cfbb96055</text>
+  </g>
+
+  <!-- B3 BIG BLUE: network at a glance -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">NETWORK AT A GLANCE</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">[PARA::0] RELAY</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+    <text x="320" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCKS FINALIZED</text>
+    <text x="320" y="514" font-size="28" font-weight="700" opacity="0.95">31,329,361</text>
+    <text x="320" y="534" font-size="10" opacity="0.5">cumulative since genesis</text>
+
+    <text x="560" y="480" font-size="11" letter-spacing="1" opacity="0.6">RUNTIME APIS</text>
+    <text x="560" y="514" font-size="28" font-weight="700" opacity="0.95">24</text>
+    <text x="560" y="534" font-size="10" opacity="0.5">exposed by runtime</text>
+
+    <text x="760" y="480" font-size="11" letter-spacing="1" opacity="0.6">REF NODE PEERS</text>
+    <text x="760" y="514" font-size="28" font-weight="700" opacity="0.95">88</text>
+    <text x="760" y="534" font-size="10" opacity="0.5">via rpc.polkadot.io</text>
+
+    <text x="920" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCK TARGET</text>
+    <text x="920" y="514" font-size="28" font-weight="700" opacity="0.95">6s</text>
+    <text x="920" y="534" font-size="10" opacity="0.5">babe slot · network parameter</text>
+
+    <text x="320" y="580" font-size="10" opacity="0.55">Token DOT · 10 decimals · SS58 format 0 · relay chain · para_id 0</text>
+    <text x="320" y="594" font-size="10" opacity="0.45">State root 0x9968aecb..86ef  ·  Genesis 0x91b171bb..ce90c3</text>
+    <text x="320" y="612" font-size="10" opacity="0.55">queried via JSON-RPC  ·  methods: chain_getFinalizedHead · chain_getHeader · state_getRuntimeVersion · system_*</text>
+  </g>
+
+  <!-- B5: chain identity (was the live chain-tip block; now static) -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">
+      <tspan fill="#E6007A" opacity="0.9">◆</tspan> AT COOKBOOK v0.18.0
+    </text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+    <text x="18" y="466" font-size="13" opacity="0.95">CHAIN      <tspan fill="#E6007A" font-weight="700">Polkadot</tspan></text>
+    <text x="18" y="486" font-size="13" opacity="0.95">TYPE       relay</text>
+    <text x="18" y="506" font-size="13" opacity="0.95">PARA_ID    0</text>
+    <text x="18" y="526" font-size="13" opacity="0.95">TOKEN      <tspan fill="#E6007A" font-weight="700">DOT</tspan>  <tspan opacity="0.6">(10 dec)</tspan></text>
+    <text x="18" y="546" font-size="13" opacity="0.95">SS58       0</text>
+    <text x="18" y="566" font-size="13" opacity="0.95">AUTHORING  BABE</text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 0x4b88a72a</text>
+  </g>
+
+  <!-- H2 tickertape — scrolling reference data (ecosystem context, not live feed).
+       Loops slowly so readers can catch all of it; the B1 disclaimer makes the
+       point-in-time nature explicit, so motion here reads as caption, not live data. -->
+  <clipPath id="tick-clip">
+    <rect x="0" y="390" width="1200" height="14"/>
+  </clipPath>
+  <g clip-path="url(#tick-clip)" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="5.3s" fill="freeze"/>
+    <text y="401" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0.9" letter-spacing="0.8">
+      <animate attributeName="x" from="1200" to="-2800" dur="75s" repeatCount="indefinite" begin="5.3s"/>
+      POLKADOT RELAY  ·  PARA_ID 0  ·  SS58 0  ·  DOT (10 dec)  ·  GENESIS 2020-05-26  ·  BLOCK 0 HASH 0x91b171bb..ce90c3  ·  6s BLOCK TARGET · ≈14,400 blocks/day  ·  BLOCK 31,329,361 · HEAD 0x4b88a72a..7d51  ·  PARENT 0x5230c003..7517  ·  STATE ROOT 0x9968aecb..86ef  ·  EXTRINSICS ROOT 0xf4c1a811..e899  ·  RUNTIME SPEC 2,002,001 · 24 APIS · TX_VERSION 26 · STATE_VERSION 1 · SYSTEM_VERSION 1 · AUTHORING_VERSION 0  ·  NODE parity-polkadot 1.22.1-f8cfbb96055  ·  QUERIED VIA rpc.polkadot.io  ·  polkadot-cookbook v0.18.0 verified against this runtime
+    </text>
+  </g>
+</svg>

--- a/.github/releases/v0.18.0/cover.svg
+++ b/.github/releases/v0.18.0/cover.svg
@@ -1,0 +1,250 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  
+  <rect width="1200" height="630" fill="#0A0A0B"/>
+
+  <!-- B1 genesis pink -->
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#0A0A0B"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#F6F5F2" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ v0.17.0..v0.18.0  2026-04-27 → 05-04 ├────────┐
+    </text>
+
+        <text x="774" y="46" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.7s" fill="freeze"/>
+      │ 306e410 ✓ chore(release-skill): resolve branch comm…
+    </text>
+    <text x="774" y="60" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.9s" fill="freeze"/>
+      │ 3ee8f39 ✓ ci: track versions.yml JS drift via self-…
+    </text>
+    <text x="774" y="74" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.1s" fill="freeze"/>
+      │ 0151961 ✓ chore(brand): remove live counts from her…
+    </text>
+    <text x="774" y="88" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.3s" fill="freeze"/>
+      │ d3dc2ba » feat: add Uniswap V3 Periphery with Hardh…
+    </text>
+    <text x="774" y="102" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.5s" fill="freeze"/>
+      │ 49a8743 ✓ chore(brand): drop misleading 'RECIPES' c…
+    </text>
+    <text x="774" y="116" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.7s" fill="freeze"/>
+      │ 8a5f738 » feat: add transfer-assets-into-polkadot p…
+    </text>
+
+    <text x="774" y="196" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ 6 commits · 2 contrib · +6,909 / -7,689 · 49 files
+    </text>
+    <text x="774" y="210" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ PRs #282 #285 #286 #287 #288 #289
+    </text>
+    <text x="774" y="224" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.55" letter-spacing="0.4">
+      └─ HEAD 8a5f738 · TAG v0.18.0 ─────────────────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;0.2;0;0.2;0" keyTimes="0;0.25;0.5;0.75;1"
+             dur="4s" begin="6.5s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- B1 PINK overlay: headline + activity + contributors -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <text x="36" y="108" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">v0.18.0</text>
+    <text x="36" y="134" font-size="11" letter-spacing="2.5" opacity="0.75">
+      MINOR RELEASE  ·  2026-04-27 → 05-04  ·  7 DAYS
+    </text>
+
+    <rect x="36" y="158" width="670" height="1" fill="#F6F5F2" opacity="0.35"/>
+
+    <text x="36" y="182" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT ACTIVITY</text>
+
+        <text x="36" y="208" font-size="12" opacity="0.9">
+      Mon 04-27  ●●  <tspan opacity="0.6">2 commits</tspan>
+    </text>
+    <text x="36" y="226" font-size="12" opacity="0.9">
+      Tue 04-28  ●  <tspan opacity="0.6">1 commits</tspan>
+    </text>
+    <text x="36" y="244" font-size="12" opacity="0.9">
+      Wed 04-29  ●●  <tspan opacity="0.6">2 commits</tspan>
+    </text>
+    <text x="36" y="262" font-size="12" opacity="0.9">
+      Mon 05-04  ●  <tspan opacity="0.6">1 commits (incl. release)</tspan>
+    </text>
+
+    <text x="36" y="320" font-size="10" letter-spacing="1.5" opacity="0.65">CONTRIBUTORS</text>
+
+        <text x="36" y="342" font-size="12" opacity="0.9">Bruno Galvao      </text>
+    <rect x="180" y="333" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="80" dur="0.6s" begin="1.30s" fill="freeze"/></rect>
+    <text x="265" y="342" font-size="12" opacity="0.95" font-weight="700">4</text>
+    <text x="36" y="360" font-size="12" opacity="0.9">Nicolás Hussein   </text>
+    <rect x="180" y="351" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="20" dur="0.6s" begin="1.45s" fill="freeze"/></rect>
+    <text x="205" y="360" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="36" y="378" font-size="12" opacity="0.9">sekiseki          </text>
+    <rect x="180" y="369" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="20" dur="0.6s" begin="1.60s" fill="freeze"/></rect>
+    <text x="205" y="378" font-size="12" opacity="0.95" font-weight="700">1</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SEMVER -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">SEMVER</text>
+    <text x="772" y="312" font-size="22" font-weight="700" opacity="0.95">MINOR</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">0.17.0 → 0.18.0</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">7 days · +6,909</text>
+  </g>
+
+  <!-- Empty cell: COMMIT TYPES -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT TYPES</text>
+
+        <text x="946" y="302" font-size="12" opacity="0.85">» feat   </text>
+    <rect x="1026" y="293" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="30" dur="0.5s" begin="4.20s" fill="freeze"/></rect>
+    <text x="1066" y="302" font-size="12" opacity="0.95" font-weight="700">2</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">✓ fix    </text>
+    <rect x="1026" y="311" width="0" height="10" fill="#E6007A" opacity="0.55"><animate attributeName="width" from="0" to="60" dur="0.5s" begin="4.35s" fill="freeze"/></rect>
+    <text x="1096" y="320" font-size="12" opacity="0.95" font-weight="700">4</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">◆ release</text>
+    <rect x="1026" y="329" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="0" dur="0.5s" begin="4.50s" fill="freeze"/></rect>
+    <text x="1036" y="338" font-size="12" opacity="0.95" font-weight="700">0</text>
+
+    <text x="946" y="368" font-size="10" opacity="0.45">SCOPES  brand · release-skill</text>
+  </g>
+
+  <!-- B3 BIG BLUE: bar chart -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">FILES CHANGED BY AREA</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">49 TOTAL</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+        <text x="320" y="466" font-size="12" opacity="0.9">polkadot-docs/chain-interactions</text>
+    <rect x="600" y="457" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="500" dur="0.70s" begin="3.30s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1110" y="466" font-size="12" opacity="0.95" font-weight="700">10</text>
+    <text x="320" y="484" font-size="12" opacity="0.9">.github/media</text>
+    <rect x="600" y="475" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="450" dur="0.68s" begin="3.40s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1060" y="484" font-size="12" opacity="0.95" font-weight="700">9</text>
+    <text x="320" y="502" font-size="12" opacity="0.9">.claude/skills</text>
+    <rect x="600" y="493" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="400" dur="0.66s" begin="3.50s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1010" y="502" font-size="12" opacity="0.95" font-weight="700">8</text>
+    <text x="320" y="520" font-size="12" opacity="0.9">polkadot-docs/smart-contracts</text>
+    <rect x="600" y="511" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="400" dur="0.66s" begin="3.60s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1010" y="520" font-size="12" opacity="0.95" font-weight="700">8</text>
+    <text x="320" y="538" font-size="12" opacity="0.9">polkadot-docs/parachains</text>
+    <rect x="600" y="529" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="300" dur="0.62s" begin="3.70s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="910" y="538" font-size="12" opacity="0.95" font-weight="700">6</text>
+    <text x="320" y="556" font-size="12" opacity="0.9">.github/workflows</text>
+    <rect x="600" y="547" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="150" dur="0.56s" begin="3.80s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="760" y="556" font-size="12" opacity="0.95" font-weight="700">3</text>
+    <text x="320" y="574" font-size="12" opacity="0.9">.github/brand</text>
+    <rect x="600" y="565" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="50" dur="0.52s" begin="3.90s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="660" y="574" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="320" y="592" font-size="12" opacity="0.9">.github/scripts</text>
+    <rect x="600" y="583" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="50" dur="0.52s" begin="4.00s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="660" y="592" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="320" y="610" font-size="12" opacity="0.9">other</text>
+    <rect x="600" y="601" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="150" dur="0.56s" begin="4.10s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="760" y="610" font-size="12" opacity="0.95" font-weight="700">3</text>
+
+    <text x="320" y="612" font-size="10" opacity="0.55">+6,909 insertions · -7,689 deletions · Δ ratio 0:1 (cleanup release)</text>
+  </g>
+
+  <!-- B5 HEAD: repo state -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">REPO @ v0.18.0</text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+        <text x="18" y="466" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700">39</tspan>  docs test harnesses
+    </text>
+    <text x="18" y="486" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 8</tspan>  recipes
+    </text>
+    <text x="18" y="506" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 2</tspan>  migration tests
+    </text>
+    <text x="18" y="526" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700">65</tspan>  CI workflows
+    </text>
+    <text x="18" y="546" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 6</tspan>  Claude skills
+    </text>
+    <text x="18" y="566" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 2</tspan>  Rust crates
+    </text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 8a5f738</text>
+  </g>
+</svg>

--- a/.github/releases/v0.18.0/manifest.yml
+++ b/.github/releases/v0.18.0/manifest.yml
@@ -1,0 +1,8 @@
+release: v0.18.0
+previous_release: v0.17.0
+release_date: 2026-05-21T00:00:00Z
+status: alpha
+
+tooling:
+  rust: "1.91.0"
+  node: "v24.7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-21
+
+### Added
+- Test harness for **Transfer Assets into Polkadot** polkadot-docs guide — verifies the XCM flow that moves assets from a remote consumer parachain into Polkadot
+- Test harness for **Uniswap V3 Periphery with Hardhat** polkadot-docs guide — exercises the full V3 Periphery deployment pipeline against pallet-revive
+- Self-healing CI workflow that detects when JavaScript harnesses fall below the `versions.yml` floor and manages a single `versions-drift` tracking issue automatically
+
+### Changed
+- Pathway banner template no longer carries the misleading `RECIPES` caption (banners are shared by recipes and polkadot-docs)
+- Hero, contributing-hero, and pathway banner templates no longer embed live counts, which previously drifted between local renders and CI
+- Release skill commit step now coexists cleanly with the local commit-msg hook
+
 ## [0.17.0] - 2026-04-22
 
 ### Added
@@ -103,7 +115,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Source URLs after upstream docs restructured periphery page
 - CI cache key to reference `docs.test.ts` after test file rename
 
-[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.15.0...v0.15.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["dot/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 authors = ["Polkadot Cookbook Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
<div align="center">
  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/55bbe64/.github/releases/v0.18.0/cover.svg" alt="Release v0.18.0" width="100%" />
</div>

## Release v0.18.0 · MINOR bump

7 commits · 3 contributors · +7,498 / -7,693 lines · 56 files changed · `v0.17.0` → `v0.18.0`

## Summary

This release adds two new documentation test harnesses — **Transfer Assets into Polkadot** (XCM) and **Uniswap V3 Periphery with Hardhat** (smart contracts) — extending coverage of the cross-chain and EVM tutorial surface. A new self-healing CI workflow now tracks JavaScript dependency drift in `versions.yml` against an automatically-managed `versions-drift` issue, and several brand templates were tightened to remove misleading captions and live counts.

## What's New

### Documentation Tests

- Added test harness for **Transfer Assets into Polkadot** — verifies the XCM flow that moves assets from a remote consumer parachain into Polkadot, so changes to the guide or upstream SDK can no longer silently break this cross-chain pattern (#288)
- Added test harness for **Uniswap V3 Periphery with Hardhat** — exercises the full Uniswap V3 deployment pipeline against pallet-revive, ensuring the EVM smart-contract tutorial keeps working as Hardhat and the dev node evolve (#286)

### Infrastructure

- Added a self-healing CI workflow that detects when JavaScript harnesses fall below the `versions.yml` floor and opens/updates a single tracked `versions-drift` issue, eliminating manual auditing of pinned JS versions across dozens of harnesses (#282)

### Tooling

- Resolved a conflict between the release skill's commit step and the local commit-msg hook so future releases no longer require manual intervention to bypass the hook (#285)
- Removed the misleading `RECIPES` caption from pathway banners — the banners are used by both recipes and polkadot-docs, so the label was inaccurate (#289)
- Removed live counts from hero, contributing-hero, and pathway banner templates — the numbers drifted between local renders and CI, undermining the apple.com-level polish those surfaces aim for (#287)

## Test plan

- [x] `cargo fmt --check --package sdk` passes
- [x] `cargo clippy --package sdk --locked -- -D warnings` passes
- [x] `cargo build --workspace --locked` succeeds
- [x] `cargo test --package sdk --lib --locked -- --test-threads=1` passes (99 passed)
- [x] `CHANGELOG.md` updated with this release's entries
- [x] `Cargo.toml` workspace version bumped to `0.18.0`
- [x] `.github/releases/v0.18.0/RELEASE_NOTES.md` reviewed and looks right
- [x] `.github/releases/v0.18.0/cover.svg` renders correctly (xmllint clean, zero unresolved tokens)
- [x] `.github/releases/v0.18.0/cover-chain.svg` renders correctly (xmllint clean, zero unresolved tokens)
