### PR TITLE
chore: sync dependency versions from polkadot-docs (stable2603-1)

### DIFF
--- a/.github/actions/setup-revive-dev-node/action.yml
+++ b/.github/actions/setup-revive-dev-node/action.yml
@@ -29,7 +29,11 @@ runs:
       if: steps.cache-revive-dev-node.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        cargo install --git https://github.com/paritytech/polkadot-sdk --tag ${{ inputs.polkadot-sdk-version }} revive-dev-node --root ~/.local
+        # --locked uses the polkadot-sdk Cargo.lock at this tag. Required because the
+        # transitive `core2` crate has been yanked from crates.io; without --locked,
+        # cargo re-resolves and fails ("failed to select a version for core2"). The
+        # yanked version is still installable when pinned by the lockfile.
+        cargo install --locked --git https://github.com/paritytech/polkadot-sdk --tag ${{ inputs.polkadot-sdk-version }} revive-dev-node --root ~/.local
 
     - name: Cache eth-rpc binary
       id: cache-eth-rpc

--- a/.github/actions/setup-zombienet-eth-rpc/zombienet.toml
+++ b/.github/actions/setup-zombienet-eth-rpc/zombienet.toml
@@ -22,5 +22,10 @@ cumulus_based = true
   name = "collator1"
   validator = true
   command = "polkadot-parachain"
-  args = ["-lparachain=debug"]
+  # --authoring slot-based is required from polkadot-stable2603 onward: the Asset
+  # Hub runtime expects the collator to supply relay-parent descendants, which
+  # the default (lookahead) collator does not. Without it the runtime panics in
+  # parachain-system ("Unable to verify provided relay parent descendants") and
+  # the parachain stays stuck at block #0.
+  args = ["-lparachain=debug", "--authoring", "slot-based"]
   rpc_port = 9988

--- a/.github/workflows/polkadot-docs-calculate-transaction-fees.yml
+++ b/.github/workflows/polkadot-docs-calculate-transaction-fees.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/calculate-transaction-fees
           npm install
-          npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+          npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
       - name: Run tests
         run: |

--- a/.github/workflows/polkadot-docs-pay-fees-different-tokens.yml
+++ b/.github/workflows/polkadot-docs-pay-fees-different-tokens.yml
@@ -78,6 +78,9 @@ jobs:
           done
           npx papi add assetHub -n polkadot_asset_hub
           cd tests/subxt-pay-fees
+          # metadata/ is gitignored, so it is absent on a fresh checkout — create it
+          # before subxt writes the .scale file (otherwise: ENOENT at the output path).
+          mkdir -p metadata
           subxt metadata --url ws://localhost:8000 -o metadata/asset_hub.scale
 
       - name: Build Subxt project

--- a/.github/workflows/polkadot-docs-query-accounts.yml
+++ b/.github/workflows/polkadot-docs-query-accounts.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/query-accounts
           npm install
-          npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+          npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
       - name: Install Python dependencies
         run: pip install substrate-interface==${{ steps.versions.outputs.SUBSTRATE_INTERFACE_VERSION }}
@@ -78,7 +78,7 @@ jobs:
       - name: Download Subxt metadata
         run: |
           cd polkadot-docs/chain-interactions/query-accounts/tests/subxt-query-account
-          subxt metadata --url wss://asset-hub-paseo.dotters.network -o polkadot_testnet_metadata.scale
+          subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o polkadot_testnet_metadata.scale
 
       - name: Build Subxt project
         run: |

--- a/.github/workflows/polkadot-docs-query-sdks.yml
+++ b/.github/workflows/polkadot-docs-query-sdks.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/query-sdks
           npm install
-          npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+          npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
       - name: Install Python dependencies
         run: pip install substrate-interface==${{ steps.versions.outputs.SUBSTRATE_INTERFACE_VERSION }}
@@ -78,7 +78,7 @@ jobs:
       - name: Download Subxt metadata
         run: |
           cd polkadot-docs/chain-interactions/query-sdks/tests/subxt-query-sdks
-          subxt metadata --url wss://asset-hub-paseo.dotters.network -o asset_hub_metadata.scale
+          subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o asset_hub_metadata.scale
 
       - name: Build Subxt project
         run: |

--- a/.github/workflows/polkadot-docs-runtime-api-calls.yml
+++ b/.github/workflows/polkadot-docs-runtime-api-calls.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/runtime-api-calls
           npm install
-          npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+          npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
       - name: Install Python dependencies
         run: pip install substrate-interface==${{ steps.versions.outputs.SUBSTRATE_INTERFACE_VERSION }}
@@ -78,7 +78,7 @@ jobs:
       - name: Download Subxt metadata
         run: |
           cd polkadot-docs/chain-interactions/runtime-api-calls/tests/subxt-runtime-api-calls
-          subxt metadata --url wss://asset-hub-paseo.dotters.network -o polkadot_testnet_metadata.scale
+          subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o polkadot_testnet_metadata.scale
 
       - name: Build Subxt project
         run: |

--- a/.github/workflows/polkadot-docs-send-transactions.yml
+++ b/.github/workflows/polkadot-docs-send-transactions.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cd polkadot-docs/chain-interactions/send-transactions
           npm install
-          npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+          npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
       - name: Install Python dependencies
         run: pip install substrate-interface==${{ steps.versions.outputs.SUBSTRATE_INTERFACE_VERSION }}
@@ -78,7 +78,7 @@ jobs:
       - name: Download Subxt metadata
         run: |
           cd polkadot-docs/chain-interactions/send-transactions/tests/subxt-send-transactions
-          subxt metadata --url wss://asset-hub-paseo.dotters.network -o asset_hub_metadata.scale
+          subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o asset_hub_metadata.scale
 
       - name: Build Subxt project
         run: |

--- a/polkadot-docs/chain-interactions/calculate-transaction-fees/README.md
+++ b/polkadot-docs/chain-interactions/calculate-transaction-fees/README.md
@@ -25,7 +25,7 @@ Both SDKs connect to Asset Hub Paseo testnet and verify that estimated fees are 
 npm install
 
 # Generate PAPI descriptors
-npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
 # Run all tests
 npm test

--- a/polkadot-docs/chain-interactions/calculate-transaction-fees/package-lock.json
+++ b/polkadot-docs/chain-interactions/calculate-transaction-fees/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot/api": "^16.5.6",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -26,12 +26,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -40,21 +40,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -92,37 +92,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -149,23 +149,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -174,14 +174,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -203,27 +203,27 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -234,21 +234,21 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -265,24 +265,24 @@
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -293,9 +293,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -306,13 +306,13 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -329,24 +329,24 @@
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -357,9 +357,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -380,9 +380,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -401,13 +401,13 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -424,24 +424,24 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -452,9 +452,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -472,13 +472,13 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
@@ -494,24 +494,24 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -522,9 +522,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -547,15 +547,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -572,24 +572,24 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -600,9 +600,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -630,16 +630,16 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -656,14 +656,14 @@
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -674,23 +674,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -707,24 +707,24 @@
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -735,18 +735,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -769,47 +769,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -850,15 +840,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -890,14 +880,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -908,9 +898,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1458,9 +1448,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1471,9 +1461,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1484,9 +1474,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1497,9 +1487,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1510,9 +1500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1523,9 +1513,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1536,9 +1526,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1549,9 +1539,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1562,9 +1552,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1575,9 +1565,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1578,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -1601,9 +1591,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1614,9 +1604,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -1627,9 +1617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1640,9 +1630,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1653,9 +1643,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1666,9 +1656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1679,9 +1669,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1692,9 +1682,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1705,9 +1695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1718,9 +1708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1731,9 +1721,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1744,9 +1734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1757,9 +1747,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -1770,9 +1760,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -1894,9 +1884,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2146,12 +2136,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2232,9 +2222,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -2245,32 +2235,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/estree-walker": {
@@ -2399,9 +2389,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2439,9 +2429,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -2570,9 +2560,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -2744,9 +2734,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -2755,7 +2745,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -2850,28 +2840,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -2902,23 +2892,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -2927,14 +2917,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -2956,9 +2946,9 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3074,12 +3064,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3089,31 +3079,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -3152,9 +3142,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3297,9 +3287,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -3414,9 +3404,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/polkadot-docs/chain-interactions/calculate-transaction-fees/package.json
+++ b/polkadot-docs/chain-interactions/calculate-transaction-fees/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^16.5.6",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/calculate-transaction-fees/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/calculate-transaction-fees/tests/docs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { ApiPromise, WsProvider } from "@polkadot/api";
 
-const WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network";
+const WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ALICE_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 const BOB_ADDRESS = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
 

--- a/polkadot-docs/chain-interactions/convert-assets/package-lock.json
+++ b/polkadot-docs/chain-interactions/convert-assets/package-lock.json
@@ -8,26 +8,26 @@
       "name": "convert-assets",
       "version": "1.0.0",
       "dependencies": {
-        "@polkadot/api": "^16.5.6",
-        "@polkadot/keyring": "^14.0.2",
-        "@polkadot/util-crypto": "^14.0.2"
+        "@polkadot/api": "16.5.6",
+        "@polkadot/keyring": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.9"
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -36,13 +36,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -70,7 +70,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1397,9 +1397,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,9 +1411,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1431,9 +1425,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1448,9 +1439,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1465,9 +1453,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1482,9 +1467,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1499,9 +1481,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1516,9 +1495,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1533,9 +1509,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1550,9 +1523,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1567,9 +1537,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1584,9 +1551,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1601,9 +1565,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1961,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2170,9 +2131,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2548,9 +2509,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3518,9 +3479,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3665,9 +3626,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3999,9 +3960,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4899,14 +4860,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5185,9 +5146,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5301,9 +5262,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5311,16 +5272,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5420,9 +5381,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5536,9 +5497,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5614,9 +5575,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5802,14 +5763,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/chain-interactions/convert-assets/package.json
+++ b/polkadot-docs/chain-interactions/convert-assets/package.json
@@ -8,11 +8,11 @@
   },
   "dependencies": {
     "@polkadot/api": "16.5.6",
-    "@polkadot/keyring": "14.0.2",
-    "@polkadot/util-crypto": "14.0.2"
+    "@polkadot/keyring": "14.0.3",
+    "@polkadot/util-crypto": "14.0.3"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/create-account/package-lock.json
+++ b/polkadot-docs/chain-interactions/create-account/package-lock.json
@@ -8,8 +8,8 @@
       "name": "create-account",
       "version": "1.0.0",
       "dependencies": {
-        "@polkadot/keyring": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
+        "@polkadot/keyring": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -443,30 +443,30 @@
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.2.tgz",
-      "integrity": "sha512-TppXBLnchsBPn5fqqJzLa1jBk2MEjZu9o9lbtQzthjW1K+1wyxqr9gS5ftSfutK69fyDc0dIeUxjgt+DHFfxHA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
+      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.2.tgz",
-      "integrity": "sha512-7pxyCbrS4fLWnFSAc55ycWH1gjQGd0Es3PBHBxl+hwHUEh5/xrBVVcXVorOjpv7T/YRmzwtjxskE3KHa4ZiNDw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
+      "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "14.0.2",
+        "@polkadot/util": "14.0.3",
         "@substrate/ss58-registry": "^1.51.0",
         "tslib": "^2.8.0"
       },
@@ -475,15 +475,15 @@
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
         "@types/bn.js": "^5.1.6",
         "bn.js": "^5.2.1",
         "tslib": "^2.8.0"
@@ -493,19 +493,19 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.2.tgz",
-      "integrity": "sha512-3THV5do8Jj3x5izA4gGi6a/FO1gllf9xSCdTTaK1InGv/Nxcc9f2NA92E9D9vEGiWidkQVQdmUNOJe5kjeIKAw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
+      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.2",
-        "@polkadot/util": "14.0.2",
+        "@polkadot/networks": "14.0.3",
+        "@polkadot/util": "14.0.3",
         "@polkadot/wasm-crypto": "^7.5.3",
         "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-randomvalues": "14.0.2",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-randomvalues": "14.0.3",
         "@scure/base": "^1.1.7",
         "@scure/sr25519": "^0.2.0",
         "tslib": "^2.8.0"
@@ -514,7 +514,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "14.0.2"
+        "@polkadot/util": "14.0.3"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -622,12 +622,12 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
+      "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "14.0.2",
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -635,9 +635,9 @@
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
+      "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -647,29 +647,29 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.2.tgz",
-      "integrity": "sha512-tyjTbPmZmHbk51hBrI8WpkWLYdER4SBXmC5W44w3nn4+k7r8lV9Hm3UGQ9GmrK6kV2cAstoPIbyzKH2jhRdrTw==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
+      "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "14.0.2",
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "14.0.2",
+        "@polkadot/util": "14.0.3",
         "@polkadot/wasm-util": "*"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
+      "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "14.0.2",
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -677,12 +677,12 @@
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
+      "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "14.0.2",
+        "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
       },
       "engines": {

--- a/polkadot-docs/chain-interactions/create-account/package.json
+++ b/polkadot-docs/chain-interactions/create-account/package.json
@@ -7,8 +7,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@polkadot/keyring": "14.0.2",
-    "@polkadot/util-crypto": "14.0.2"
+    "@polkadot/keyring": "14.0.3",
+    "@polkadot/util-crypto": "14.0.3"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/debug-and-preview-xcms/package-lock.json
+++ b/polkadot-docs/chain-interactions/debug-and-preview-xcms/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot-api/descriptors": "file:.papi/descriptors",
-        "@polkadot-labs/hdkd": "^0.0.27",
-        "@polkadot-labs/hdkd-helpers": "^0.0.28",
+        "@polkadot-labs/hdkd": "^0.0.28",
+        "@polkadot-labs/hdkd-helpers": "^0.0.30",
         "@polkadot/api": "^16.5.6",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.12.0",
         "typescript": "^5.7.3",
         "vitest": "^2.1.9"
@@ -29,14 +29,14 @@
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -45,13 +45,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -64,13 +64,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -79,7 +79,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -91,13 +91,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -120,12 +120,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -134,21 +134,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dmsnell/diff-match-patch": {
@@ -157,448 +157,6 @@
       "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -817,37 +375,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.3.tgz",
-      "integrity": "sha512-aEvUuw9Fd+syt430hJjO8q04QNWmuqlOMbD9WZwLdeMAiGR0+F5h/CUF4tSybiNcbL5jDWLTzrraL5qdSfjm3w==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.2",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -862,23 +420,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -887,14 +445,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -916,12 +474,12 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
@@ -938,43 +496,43 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -989,35 +547,35 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1042,9 +600,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.2.tgz",
-      "integrity": "sha512-AlOpIbKLcilTf87/unNuZaNQG6IFr9QrP3i7p9SCU1LO8DqVkkWGlQ5CWqnxci1NAXLeRKlSO9M2E/UZVTxdBg==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -1063,35 +621,35 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1113,34 +671,34 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1167,37 +725,37 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1229,28 +787,28 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1261,36 +819,36 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1301,9 +859,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1326,47 +884,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1430,15 +978,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.2.tgz",
-      "integrity": "sha512-x3WuA59NrcIbhfFw+LRnlDNRdMRdg9Wz8OCK6HUjjwFfL/O+yNtf/pTGuINuOigZzmBj7hHixPaVw9VJogCN6Q==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -1458,14 +1006,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1508,23 +1056,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-labs/hdkd": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.27.tgz",
-      "integrity": "sha512-S+cQErugqWhDy9K9uceDmnRiIezVfu/yLLFlBSk6vHQ8/RjtUDS7aTnYWpZlbwR99dNuh077ptd0P8M1tx1DHA==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.28.tgz",
+      "integrity": "sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-labs/hdkd-helpers": "~0.0.28"
+        "@polkadot-labs/hdkd-helpers": "~0.0.29"
       }
     },
     "node_modules/@polkadot-labs/hdkd-helpers": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.28.tgz",
-      "integrity": "sha512-kENij83Dr76RrcfsJmzcqNhThjWTPtzregb/i6o50kH5n1wkaE58/8PFahMnGVc9Trzk7jxfGSNQphQNwq2emg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.30.tgz",
+      "integrity": "sha512-qWmmD6ayj14RenDuDFfjF3sHS7ObqPzwIIMPcSVoDeKFSeQV7RY0HwyhC5CG4i6FoguMzak2dbtjYpNN5XQiwQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@scure/base": "^2.0.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.2.0",
         "@scure/sr25519": "^1.0.0",
         "scale-ts": "^1.6.1"
       }
@@ -2088,9 +1636,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -2101,9 +1649,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -2114,9 +1662,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -2127,9 +1675,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -2140,9 +1688,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -2153,9 +1701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -2166,14 +1714,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2182,14 +1727,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2198,14 +1740,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2214,14 +1753,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2230,14 +1766,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2246,14 +1779,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2262,14 +1792,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2278,14 +1805,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2294,14 +1818,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2310,14 +1831,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2326,14 +1844,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2342,14 +1857,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2358,14 +1870,11 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2374,9 +1883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -2387,9 +1896,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -2400,9 +1909,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -2413,9 +1922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -2426,9 +1935,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2439,9 +1948,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2461,9 +1970,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2611,9 +2120,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2833,9 +2342,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3003,9 +2512,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3352,12 +2861,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -3421,9 +2930,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3732,9 +3241,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -3745,32 +3254,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -4360,9 +3869,9 @@
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -4540,9 +4049,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4756,9 +4265,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5101,9 +4610,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5307,9 +4816,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -5318,7 +4827,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -5557,28 +5066,28 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.2.tgz",
-      "integrity": "sha512-eYj7VUVuZu4CibGnhJGfixqiGc5IIiJX87fNpW+UVvqht3DxVBWpPpUCDwP6AH4lKY97zgNfp4o18HMgp9aV2Q==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.2",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -5597,23 +5106,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -5622,14 +5131,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -5988,12 +5497,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6003,31 +5512,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -6326,14 +5835,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -6534,9 +6043,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -6730,9 +6239,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6830,9 +6339,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
-      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -6860,9 +6369,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6870,16 +6379,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -6979,9 +6488,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7117,9 +6626,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7222,9 +6731,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -7863,14 +7372,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/chain-interactions/debug-and-preview-xcms/package.json
+++ b/polkadot-docs/chain-interactions/debug-and-preview-xcms/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "@polkadot-api/descriptors": "file:.papi/descriptors",
-    "@polkadot-labs/hdkd": "^0.0.27",
-    "@polkadot-labs/hdkd-helpers": "^0.0.28",
+    "@polkadot-labs/hdkd": "^0.0.28",
+    "@polkadot-labs/hdkd-helpers": "^0.0.30",
     "@polkadot/api": "^16.5.6",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.12.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/package-lock.json
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot/api": "16.5.6",
-        "@polkadot/keyring": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
+        "@polkadot/keyring": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.12.0",
         "typescript": "^5.7.3",
         "vitest": "^2.1.9"
@@ -28,14 +28,14 @@
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -44,13 +44,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -63,13 +63,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -78,7 +78,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -90,13 +90,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -492,108 +492,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api-derive/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api-derive/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/keyring": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
@@ -609,140 +508,6 @@
       "peerDependencies": {
         "@polkadot/util": "14.0.3",
         "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/api/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/keyring": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.2.tgz",
-      "integrity": "sha512-TppXBLnchsBPn5fqqJzLa1jBk2MEjZu9o9lbtQzthjW1K+1wyxqr9gS5ftSfutK69fyDc0dIeUxjgt+DHFfxHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/networks": {
@@ -816,98 +581,6 @@
       },
       "optionalDependencies": {
         "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
-      "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.3",
-        "@polkadot/util": "14.0.3",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-randomvalues": "14.0.3",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot/types": {
@@ -1002,52 +675,25 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/types/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/util": {
       "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
+      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
+        "@polkadot/x-bigint": "14.0.3",
+        "@polkadot/x-global": "14.0.3",
+        "@polkadot/x-textdecoder": "14.0.3",
+        "@polkadot/x-textencoder": "14.0.3",
+        "@types/bn.js": "^5.1.6",
+        "bn.js": "^5.2.1",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
-    "node_modules/@polkadot/types/node_modules/@polkadot/util-crypto": {
+    "node_modules/@polkadot/util-crypto": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
       "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
@@ -1070,71 +716,6 @@
       },
       "peerDependencies": {
         "@polkadot/util": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@scure/sr25519": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
-      "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/curves": "~1.9.2",
-        "@noble/hashes": "~1.8.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/util": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
-      "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.3",
-        "@polkadot/x-global": "14.0.3",
-        "@polkadot/x-textdecoder": "14.0.3",
-        "@polkadot/x-textencoder": "14.0.3",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.2.tgz",
-      "integrity": "sha512-3THV5do8Jj3x5izA4gGi6a/FO1gllf9xSCdTTaK1InGv/Nxcc9f2NA92E9D9vEGiWidkQVQdmUNOJe5kjeIKAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.2",
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-randomvalues": "14.0.2",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2"
       }
     },
     "node_modules/@polkadot/util-crypto/node_modules/@noble/curves": {
@@ -1162,106 +743,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.2.tgz",
-      "integrity": "sha512-7pxyCbrS4fLWnFSAc55ycWH1gjQGd0Es3PBHBxl+hwHUEh5/xrBVVcXVorOjpv7T/YRmzwtjxskE3KHa4ZiNDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.2.tgz",
-      "integrity": "sha512-tyjTbPmZmHbk51hBrI8WpkWLYdER4SBXmC5W44w3nn4+k7r8lV9Hm3UGQ9GmrK6kV2cAstoPIbyzKH2jhRdrTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/util-crypto/node_modules/@scure/base": {
@@ -1578,9 +1059,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1595,9 +1073,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1612,9 +1087,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1629,9 +1101,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1646,9 +1115,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1663,9 +1129,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1680,9 +1143,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,9 +1157,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1714,9 +1171,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,9 +1185,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1748,9 +1199,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1765,9 +1213,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1782,9 +1227,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2173,9 +1615,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2343,9 +1785,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2714,9 +2156,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3161,6 +2603,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -3263,38 +2718,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/gauge/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/get-caller-file": {
@@ -3664,9 +3087,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3811,9 +3234,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4145,9 +3568,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4974,17 +4397,12 @@
       "license": "ISC"
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "optional": true
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -5056,14 +4474,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5204,6 +4622,21 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
@@ -5221,6 +4654,13 @@
       }
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
@@ -5334,9 +4774,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5437,9 +4877,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5447,16 +4887,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5556,9 +4996,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5604,13 +5044,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/typeorm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typeorm/node_modules/glob": {
       "version": "10.5.0",
@@ -5660,21 +5093,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/typeorm/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/typeorm/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -5694,9 +5112,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5772,9 +5190,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -6404,14 +5822,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -6451,30 +5869,6 @@
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
-      }
-    },
-    "node_modules/wide-align/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -6528,28 +5922,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/package.json
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/package.json
@@ -8,11 +8,11 @@
   },
   "dependencies": {
     "@polkadot/api": "16.5.6",
-    "@polkadot/keyring": "14.0.2",
-    "@polkadot/util-crypto": "14.0.2"
+    "@polkadot/keyring": "14.0.3",
+    "@polkadot/util-crypto": "14.0.3"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.12.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-asset-hub.yml
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-asset-hub.yml
@@ -1,4 +1,6 @@
-endpoint: wss://asset-hub-paseo.dotters.network
+endpoint:
+  - wss://api2.zondax.ch/pas/assethub/node/rpc
+  - wss://asset-hub-paseo-rpc.n.dwellir.com
 mock-signature-host: true
 db: ./db-asset-hub.sqlite
 

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-asset-hub.yml
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-asset-hub.yml
@@ -1,4 +1,4 @@
-endpoint: wss://asset-hub-paseo-rpc.n.dwellir.com
+endpoint: wss://asset-hub-paseo.dotters.network
 mock-signature-host: true
 db: ./db-asset-hub.sqlite
 

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-people-chain.yml
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-people-chain.yml
@@ -1,4 +1,4 @@
-endpoint: wss://people-paseo.rpc.amforc.com
+endpoint: wss://people-paseo.dotters.network
 mock-signature-host: true
 db: ./db-people-chain.sqlite
 

--- a/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-people-chain.yml
+++ b/polkadot-docs/chain-interactions/estimate-xcm-fees/paseo-people-chain.yml
@@ -1,4 +1,6 @@
-endpoint: wss://people-paseo.dotters.network
+endpoint:
+  - wss://api2.zondax.ch/pas/people/node/rpc
+  - wss://people-paseo.rpc.amforc.com
 mock-signature-host: true
 db: ./db-people-chain.sqlite
 

--- a/polkadot-docs/chain-interactions/pay-fees-different-tokens/package-lock.json
+++ b/polkadot-docs/chain-interactions/pay-fees-different-tokens/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot-api/descriptors": "file:.papi/descriptors",
-        "@polkadot-labs/hdkd": "^0.0.27",
-        "@polkadot-labs/hdkd-helpers": "^0.0.28",
+        "@polkadot-labs/hdkd": "^0.0.28",
+        "@polkadot-labs/hdkd-helpers": "^0.0.30",
         "@polkadot/api": "^16.5.6",
         "@polkadot/keyring": "^14.0.3",
         "@polkadot/util-crypto": "^14.0.3",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.9"
@@ -31,14 +31,14 @@
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -47,13 +47,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -66,13 +66,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -81,7 +81,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -140,13 +140,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -310,12 +310,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -324,21 +324,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dmsnell/diff-match-patch": {
@@ -454,12 +454,12 @@
       "license": "MIT"
     },
     "node_modules/@noble/curves": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
-      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.0.1"
+        "@noble/hashes": "2.2.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -469,9 +469,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -565,54 +565,42 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
         "papi": "dist/main/src/main.js",
         "polkadot-api": "dist/main/src/main.js"
-      }
-    },
-    "node_modules/@polkadot-api/cli/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/json-rpc-provider": {
@@ -622,23 +610,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -647,14 +635,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -676,18 +664,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -698,55 +686,43 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/codegen/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -761,47 +737,35 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/ink-contracts/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -826,9 +790,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -847,47 +811,35 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/merkleize-metadata/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -909,46 +861,34 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
-      }
-    },
-    "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -975,49 +915,37 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/pjs-signer/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1049,40 +977,28 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/signer/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1093,48 +1009,36 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
-    "node_modules/@polkadot-api/signers-common/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1145,9 +1049,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1170,47 +1074,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1274,31 +1168,19 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
         "rxjs": ">=7.8.0"
-      }
-    },
-    "node_modules/@polkadot-api/ws-middleware/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/json-rpc-provider": {
@@ -1314,14 +1196,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1364,23 +1246,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-labs/hdkd": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.27.tgz",
-      "integrity": "sha512-S+cQErugqWhDy9K9uceDmnRiIezVfu/yLLFlBSk6vHQ8/RjtUDS7aTnYWpZlbwR99dNuh077ptd0P8M1tx1DHA==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.28.tgz",
+      "integrity": "sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-labs/hdkd-helpers": "~0.0.28"
+        "@polkadot-labs/hdkd-helpers": "~0.0.29"
       }
     },
     "node_modules/@polkadot-labs/hdkd-helpers": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.28.tgz",
-      "integrity": "sha512-kENij83Dr76RrcfsJmzcqNhThjWTPtzregb/i6o50kH5n1wkaE58/8PFahMnGVc9Trzk7jxfGSNQphQNwq2emg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.30.tgz",
+      "integrity": "sha512-qWmmD6ayj14RenDuDFfjF3sHS7ObqPzwIIMPcSVoDeKFSeQV7RY0HwyhC5CG4i6FoguMzak2dbtjYpNN5XQiwQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@scure/base": "^2.0.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.2.0",
         "@scure/sr25519": "^1.0.0",
         "scale-ts": "^1.6.1"
       }
@@ -2735,9 +2617,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -2748,9 +2630,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -2761,9 +2643,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -2774,9 +2656,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -2787,9 +2669,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -2800,9 +2682,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -2813,9 +2695,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -2826,9 +2708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -2839,9 +2721,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -2852,9 +2734,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2865,9 +2747,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -2878,9 +2760,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -2891,9 +2773,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -2904,9 +2786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -2917,9 +2799,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -2930,9 +2812,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -2943,9 +2825,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -2956,9 +2838,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -2969,9 +2851,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -2982,9 +2864,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -2995,9 +2877,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -3008,9 +2890,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -3021,9 +2903,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -3034,9 +2916,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -3047,9 +2929,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -3069,9 +2951,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3086,6 +2968,33 @@
         "@noble/curves": "~2.0.0",
         "@noble/hashes": "~2.0.0"
       },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/sr25519/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -3192,9 +3101,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3414,9 +3323,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3584,9 +3493,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3676,15 +3585,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3933,12 +3842,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {
@@ -4002,9 +3911,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4313,9 +4222,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -4326,32 +4235,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -4440,9 +4349,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
-      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4941,9 +4850,9 @@
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -5121,9 +5030,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5337,9 +5246,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5682,9 +5591,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5888,9 +5797,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -5899,7 +5808,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -6138,28 +6047,28 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -6171,18 +6080,6 @@
         "rxjs": ">=7.8.0"
       }
     },
-    "node_modules/polkadot-api/node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/polkadot-api/node_modules/@polkadot-api/json-rpc-provider": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.2.0.tgz",
@@ -6190,23 +6087,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -6215,14 +6112,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -6581,12 +6478,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6596,31 +6493,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -6919,14 +6816,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7127,9 +7024,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -7323,9 +7220,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7423,9 +7320,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -7453,9 +7350,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7463,16 +7360,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -7572,9 +7469,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7710,9 +7607,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7815,9 +7712,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -8456,14 +8353,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/chain-interactions/pay-fees-different-tokens/package.json
+++ b/polkadot-docs/chain-interactions/pay-fees-different-tokens/package.json
@@ -8,15 +8,15 @@
   },
   "dependencies": {
     "@polkadot-api/descriptors": "file:.papi/descriptors",
-    "@polkadot-labs/hdkd": "^0.0.27",
-    "@polkadot-labs/hdkd-helpers": "^0.0.28",
+    "@polkadot-labs/hdkd": "^0.0.28",
+    "@polkadot-labs/hdkd-helpers": "^0.0.30",
     "@polkadot/api": "^16.5.6",
     "@polkadot/keyring": "^14.0.3",
     "@polkadot/util-crypto": "^14.0.3",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/docs.test.ts
@@ -56,16 +56,36 @@ async function waitForChopsticks(
 }
 
 async function stopChopsticks(): Promise<void> {
-  if (chopsticksProcess && !chopsticksProcess.killed) {
+  const proc = chopsticksProcess;
+  chopsticksProcess = null;
+
+  if (proc && !proc.killed) {
+    // Kill only our own process group (spawned with detached: true). A broad
+    // `pkill -f chopsticks` matches an ancestor of the kill command and gets
+    // SIGTERM'd itself, which throws past the `|| true` and fails the suite.
     try {
-      process.kill(-chopsticksProcess.pid!, "SIGTERM");
+      process.kill(-proc.pid!, "SIGTERM");
     } catch {
-      chopsticksProcess.kill("SIGTERM");
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // ignore
+      }
     }
-    chopsticksProcess = null;
+
+    await new Promise((r) => setTimeout(r, 2000));
+
+    // Force-kill if still alive
+    try {
+      process.kill(-proc.pid!, "SIGKILL");
+    } catch {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // ignore
+      }
+    }
   }
-  execSync("pkill -f 'chopsticks' 2>/dev/null || true", { encoding: "utf-8" });
-  await new Promise((r) => setTimeout(r, 2000));
 }
 
 // ---------------------------------------------------------------------------

--- a/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/subxt-pay-fees/Cargo.lock
+++ b/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/subxt-pay-fees/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-channel"
@@ -204,9 +204,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base58"
@@ -238,32 +244,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -297,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "constant_time_eq 0.4.2",
 ]
 
@@ -343,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -361,15 +388,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -436,11 +463,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -706,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -749,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -791,6 +819,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,12 +865,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -957,9 +991,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1022,28 +1056,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1069,7 +1097,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec 0.7.7",
 ]
 
 [[package]]
@@ -1104,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1219,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1258,12 +1295,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1336,21 +1373,20 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -1360,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4280b709ac3bb5e16cf3bad5056a0ec8df55fa89edfe996361219aadc2c7ea"
+checksum = "b3e1420b1792cff778e2a1ebaa44115f156ee62a94dd106eaa51163f037d2023"
 dependencies = [
  "base64",
  "futures-util",
@@ -1383,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -1403,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
 dependencies = [
  "http",
  "serde",
@@ -1415,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fc744f17e7926d57f478cf9ca6e1ee5d8332bf0514860b1a3cdf1742e614cc"
+checksum = "9df5bd5c38c0906a6e8b3a38c8c22cc8525fda25fd1a03a3fe010686aea66b70"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -1446,10 +1482,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.184"
+name = "konst"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1528,24 +1579,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "merlin"
@@ -1561,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1654,7 +1705,7 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "bitvec",
  "byte-slice-cast",
  "const_format",
@@ -1744,18 +1795,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1813,6 +1864,12 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1887,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1902,9 +1959,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1941,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1964,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ring"
@@ -2018,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -2033,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2045,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2081,9 +2138,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2098,9 +2155,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff0cc5e135c8870a775d3320910cd9b564ec036b4dc0b8741629020be63f01"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 
 [[package]]
 name = "ryu"
@@ -2293,7 +2350,7 @@ checksum = "6e9fcb6c2e176e86ec703e22560d99d65a5ee9056ae45a08e13e84ebf796296f"
 dependencies = [
  "aead",
  "arrayref",
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
@@ -2422,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2483,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -2493,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2515,9 +2572,9 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2536,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol"
@@ -2559,13 +2616,14 @@ dependencies = [
 
 [[package]]
 name = "smoldot"
-version = "0.20.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724ab10d6485cccb4bab080ce436c0b361295274aec7847d7ba84ab1a79a5132"
+checksum = "5e8b3be57abd860ec235a62084ad8a72772d4bf799ba26aa3aefc282273fcf5e"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "async-lock",
  "atomic-take",
+ "base32",
  "base64",
  "bip39",
  "blake2-rfc",
@@ -2576,10 +2634,11 @@ dependencies = [
  "ed25519-zebra",
  "either",
  "event-listener",
+ "fastbloom",
  "fnv",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "hmac 0.12.1",
  "itertools",
@@ -2613,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "smoldot-light"
-version = "0.18.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b4d4971f06f2471f4e57a662dbe8047fa0cc020957764a6211f3fad371f7bd"
+checksum = "f41c13af52cfe0baf5e2c04c2ee21891b64f13d2609a0f59a0e00224e88492c4"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -2629,7 +2688,7 @@ dependencies = [
  "futures-channel",
  "futures-lite",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "itertools",
  "log",
@@ -2649,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2728,9 +2787,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subxt"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00586d7007aa4fb3321dd9c6f84e960d156b97951f0894ea49a9dc227ca4babd"
+checksum = "cfdd3390b653a6b7556312314ba2c2b8639433d5a3ae24ce8bcfe940c54c0c5e"
 dependencies = [
  "async-trait",
  "derive-where",
@@ -2769,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc64ea7c2cb00c991907b4e492f8278525abad39dc718541672c7ae057dd260"
+checksum = "35e0a556b73141291c48fe73fea3cc6f3f89a65b290bf417337e5f9886fcc268"
 dependencies = [
  "heck",
  "parity-scale-codec",
@@ -2786,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74b4e6f8c5494b54e0b2cf0bdb2d223b51735b9f0d4fe4aff400a57b2d555d8"
+checksum = "961bd1b7d5531f7a6b8086364eb4c6c09b21675e5e8b29b56ea281187d151eef"
 dependencies = [
  "futures",
  "futures-util",
@@ -2803,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c2aa051ad10633aeb8e68b02b7fbd639ce7d58f27058622c9c031a2b2cc89"
+checksum = "71424eb24c87275b9afdf2cce5fc778e93d5b4a419418f09e7a5a242a08241c0"
 dependencies = [
  "darling",
  "parity-scale-codec",
@@ -2820,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364cd732cdc47381240e4756c47a345009f2bf299754d4b3b07ce261d95d3005"
+checksum = "3d05ecf00bb0a10307c195f8c924ff8e20ab4a274569ffc981beb802211b12af"
 dependencies = [
  "frame-decode",
  "frame-metadata",
@@ -2847,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-rpcs"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5929c336747a2f98ad0bcef571529faadcb3e349d4ef12bb7999174840ac957f"
+checksum = "15e4b23044ba59654f30e25cc48f8865e70439ee137764793cdfb0f8452dc638"
 dependencies = [
  "derive-where",
  "frame-metadata",
@@ -2870,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5e6417a22233f9731cd8a151a5c3d407c65b0199da0f799cf0ed1c753693a"
+checksum = "a62298e417e46990aac99c88d8bf1bfd80cfb66038adc6c9cb27ee270433d7ae"
 dependencies = [
  "base64",
  "bip39",
@@ -2898,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-accountid32"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e03d4e3bbcf88379985dc6d2a5718d58ddaa09f3d40f21ef7d8749c62b70d44"
+checksum = "0fe4b05efc5c0e997a914bbf33644d63c35ee20b3060ac7af120e60148269cad"
 dependencies = [
  "base58",
  "blake2",
@@ -2914,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccff94b31e98f551e35ddf20397d6ba55ab69dfd12edda0037b428fc8f99c65"
+checksum = "204fe7ffe357d92292e243634a20a3f5dc3e881843c16a42e6c0ee581d1e6c4c"
 dependencies = [
  "hex",
  "parity-scale-codec",
@@ -2925,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3027,9 +3086,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "libc",
  "mio",
@@ -3096,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3166,9 +3225,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -3199,9 +3258,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -3273,9 +3332,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3286,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3296,9 +3355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3306,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3319,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -3332,7 +3391,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19af97fcb96045dd1d6b4d23e2b4abdbbe81723dbc5c9f016eb52145b320063"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.7",
  "multi-stash",
  "smallvec",
  "spin",
@@ -3392,14 +3451,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.8",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3578,9 +3637,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3620,9 +3679,9 @@ checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3643,18 +3702,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3663,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3684,18 +3743,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/subxt-pay-fees/Cargo.toml
+++ b/polkadot-docs/chain-interactions/pay-fees-different-tokens/tests/subxt-pay-fees/Cargo.toml
@@ -11,6 +11,6 @@ path = "src/bin/fee_payment_transaction.rs"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3", features = ["derive"] }
-subxt = "0.50.0"
-subxt-signer = { version = "0.50.0", features = ["sr25519", "subxt"] }
+subxt = "0.50.1"
+subxt-signer = { version = "0.50.1", features = ["sr25519", "subxt"] }
 tokio = { version = "1.44.2", features = ["macros", "rt"] }

--- a/polkadot-docs/chain-interactions/query-accounts/README.md
+++ b/polkadot-docs/chain-interactions/query-accounts/README.md
@@ -28,14 +28,14 @@ All SDKs query the same account on Asset Hub Paseo testnet and verify the respon
 npm ci
 
 # Generate PAPI descriptors
-npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
 # Install Python dependency
 pip install substrate-interface
 
 # Download Subxt metadata and build
 cd tests/subxt-query-account
-subxt metadata --url wss://asset-hub-paseo.dotters.network -o polkadot_testnet_metadata.scale
+subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o polkadot_testnet_metadata.scale
 cargo build
 cd ../..
 

--- a/polkadot-docs/chain-interactions/query-accounts/package-lock.json
+++ b/polkadot-docs/chain-interactions/query-accounts/package-lock.json
@@ -12,7 +12,7 @@
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot/api": "^16.5.6",
         "dedot": "^1.0.4",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -34,12 +34,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -48,21 +48,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dedot/api": {
@@ -697,37 +697,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -754,23 +754,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -779,14 +779,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -808,27 +808,27 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -839,21 +839,21 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -870,24 +870,24 @@
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -898,9 +898,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -911,13 +911,13 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -934,24 +934,24 @@
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -962,9 +962,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -985,9 +985,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -1006,13 +1006,13 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -1029,24 +1029,24 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1057,9 +1057,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1077,13 +1077,13 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
@@ -1099,24 +1099,24 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1127,9 +1127,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1152,15 +1152,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -1177,24 +1177,24 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1205,9 +1205,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1235,16 +1235,16 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -1261,14 +1261,14 @@
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1279,23 +1279,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -1312,24 +1312,24 @@
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1340,18 +1340,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1374,47 +1374,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1455,15 +1445,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -1495,14 +1485,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1513,9 +1503,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2063,9 +2053,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -2076,9 +2066,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -2089,9 +2079,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -2102,9 +2092,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -2115,9 +2105,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -2128,9 +2118,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -2141,9 +2131,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -2154,9 +2144,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -2167,9 +2157,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -2180,9 +2170,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -2193,9 +2183,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -2206,9 +2196,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -2219,9 +2209,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -2232,9 +2222,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -2245,9 +2235,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -2258,9 +2248,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -2271,9 +2261,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -2284,9 +2274,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -2297,9 +2287,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -2310,9 +2300,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -2323,9 +2313,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -2336,9 +2326,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -2349,9 +2339,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -2362,9 +2352,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2375,9 +2365,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2526,9 +2516,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2867,12 +2857,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -3242,9 +3232,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -3397,9 +3387,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3586,9 +3576,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -3597,7 +3587,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -3744,28 +3734,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -3796,23 +3786,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -3821,14 +3811,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -3850,9 +3840,9 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3992,12 +3982,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4007,31 +3997,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -4070,9 +4060,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4212,9 +4202,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4341,9 +4331,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/polkadot-docs/chain-interactions/query-accounts/package.json
+++ b/polkadot-docs/chain-interactions/query-accounts/package.json
@@ -11,7 +11,7 @@
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^16.5.6",
     "dedot": "^1.0.4",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/query-accounts/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/query-accounts/tests/docs.test.ts
@@ -4,7 +4,7 @@ import { DedotClient, WsProvider as DedotWsProvider } from "dedot";
 import { execSync } from "child_process";
 import { join } from "path";
 
-const WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network";
+const WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 
 // ---------------------------------------------------------------------------

--- a/polkadot-docs/chain-interactions/query-accounts/tests/query_account.py
+++ b/polkadot-docs/chain-interactions/query-accounts/tests/query_account.py
@@ -1,6 +1,6 @@
 from substrateinterface import SubstrateInterface
 
-WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network"
+WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc"
 ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg"
 
 

--- a/polkadot-docs/chain-interactions/query-accounts/tests/subxt-query-account/src/main.rs
+++ b/polkadot-docs/chain-interactions/query-accounts/tests/subxt-query-account/src/main.rs
@@ -5,7 +5,7 @@ use subxt::{OnlineClient, PolkadotConfig};
 #[subxt::subxt(runtime_metadata_path = "polkadot_testnet_metadata.scale")]
 pub mod polkadot_testnet {}
 
-const POLKADOT_TESTNET_RPC: &str = "wss://asset-hub-paseo.dotters.network";
+const POLKADOT_TESTNET_RPC: &str = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS: &str = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 
 #[tokio::main(flavor = "current_thread")]

--- a/polkadot-docs/chain-interactions/query-sdks/README.md
+++ b/polkadot-docs/chain-interactions/query-sdks/README.md
@@ -34,14 +34,14 @@ All SDKs query the same accounts on Paseo Asset Hub testnet.
 npm ci
 
 # Generate PAPI descriptors
-npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
 # Install Python dependency
 pip install substrate-interface
 
 # Download Subxt metadata and build
 cd tests/subxt-query-sdks
-subxt metadata --url wss://asset-hub-paseo.dotters.network -o asset_hub_metadata.scale
+subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o asset_hub_metadata.scale
 cargo build
 cd ../..
 

--- a/polkadot-docs/chain-interactions/query-sdks/package-lock.json
+++ b/polkadot-docs/chain-interactions/query-sdks/package-lock.json
@@ -12,7 +12,7 @@
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot/api": "^16.5.6",
         "dedot": "^1.0.4",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -34,12 +34,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -48,21 +48,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dedot/api": {
@@ -329,37 +329,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -386,23 +386,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -411,14 +411,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -440,27 +440,27 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -471,21 +471,21 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -502,24 +502,24 @@
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -530,9 +530,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -543,13 +543,13 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -566,24 +566,24 @@
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -594,9 +594,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -617,9 +617,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -638,13 +638,13 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -661,24 +661,24 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -689,9 +689,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -709,13 +709,13 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
@@ -731,24 +731,24 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -759,9 +759,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -784,15 +784,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -809,24 +809,24 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -837,9 +837,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -867,16 +867,16 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -893,14 +893,14 @@
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -911,23 +911,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -944,24 +944,24 @@
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -972,18 +972,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1006,47 +1006,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1087,15 +1077,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -1127,14 +1117,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1145,9 +1135,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1695,9 +1685,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1708,9 +1698,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1721,9 +1711,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1734,9 +1724,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1747,9 +1737,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1760,9 +1750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1773,9 +1763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1786,9 +1776,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1799,9 +1789,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1812,9 +1802,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1815,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -1838,9 +1828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1851,9 +1841,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -1864,9 +1854,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1877,9 +1867,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1890,9 +1880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1903,9 +1893,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1916,9 +1906,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1929,9 +1919,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1942,9 +1932,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +1945,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1968,9 +1958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1981,9 +1971,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1994,9 +1984,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +1997,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2158,9 +2148,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2513,12 +2503,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2646,9 +2636,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -2659,32 +2649,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -2892,9 +2882,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -3047,9 +3037,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3236,9 +3226,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -3247,7 +3237,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -3393,28 +3383,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -3445,23 +3435,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -3470,14 +3460,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -3499,9 +3489,9 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3641,12 +3631,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3656,31 +3646,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -3719,9 +3709,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3861,9 +3851,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3990,9 +3980,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/polkadot-docs/chain-interactions/query-sdks/package.json
+++ b/polkadot-docs/chain-interactions/query-sdks/package.json
@@ -11,7 +11,7 @@
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^16.5.6",
     "dedot": "^1.0.4",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/query-sdks/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/query-sdks/tests/docs.test.ts
@@ -5,7 +5,7 @@ import { hexToString } from "dedot/utils";
 import { execSync } from "child_process";
 import { join } from "path";
 
-const WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network";
+const WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 const USDT_ASSET_ID = 1984;
 const USDT_HOLDER_ADDRESS =

--- a/polkadot-docs/chain-interactions/query-sdks/tests/query_asset.py
+++ b/polkadot-docs/chain-interactions/query-sdks/tests/query_asset.py
@@ -1,6 +1,6 @@
 from substrateinterface import SubstrateInterface
 
-WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network"
+WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc"
 USDT_ASSET_ID = 1984
 USDT_HOLDER_ADDRESS = "13rxtPcR9nsAMzLKJsj6UevMR9TzGmyRohJVgQ6U6K2xeqU3"
 

--- a/polkadot-docs/chain-interactions/query-sdks/tests/query_balance.py
+++ b/polkadot-docs/chain-interactions/query-sdks/tests/query_balance.py
@@ -1,6 +1,6 @@
 from substrateinterface import SubstrateInterface
 
-WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network"
+WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc"
 ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg"
 
 

--- a/polkadot-docs/chain-interactions/query-sdks/tests/subxt-query-sdks/src/bin/query_asset.rs
+++ b/polkadot-docs/chain-interactions/query-sdks/tests/subxt-query-sdks/src/bin/query_asset.rs
@@ -5,7 +5,7 @@ use subxt::{OnlineClient, PolkadotConfig};
 #[subxt::subxt(runtime_metadata_path = "asset_hub_metadata.scale")]
 pub mod asset_hub {}
 
-const ASSET_HUB_RPC: &str = "wss://asset-hub-paseo.dotters.network";
+const ASSET_HUB_RPC: &str = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const USDT_ASSET_ID: u32 = 1984;
 const USDT_HOLDER_ADDRESS: &str = "13rxtPcR9nsAMzLKJsj6UevMR9TzGmyRohJVgQ6U6K2xeqU3";
 

--- a/polkadot-docs/chain-interactions/query-sdks/tests/subxt-query-sdks/src/bin/query_balance.rs
+++ b/polkadot-docs/chain-interactions/query-sdks/tests/subxt-query-sdks/src/bin/query_balance.rs
@@ -5,7 +5,7 @@ use subxt::{OnlineClient, PolkadotConfig};
 #[subxt::subxt(runtime_metadata_path = "asset_hub_metadata.scale")]
 pub mod asset_hub {}
 
-const ASSET_HUB_RPC: &str = "wss://asset-hub-paseo.dotters.network";
+const ASSET_HUB_RPC: &str = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS: &str = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 
 #[tokio::main(flavor = "current_thread")]

--- a/polkadot-docs/chain-interactions/register-foreign-asset/package-lock.json
+++ b/polkadot-docs/chain-interactions/register-foreign-asset/package-lock.json
@@ -13,21 +13,21 @@
         "@polkadot/util-crypto": "^14.0.3"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.9"
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -36,13 +36,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -70,7 +70,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1961,9 +1961,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2131,9 +2131,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2509,9 +2509,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3479,9 +3479,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3626,9 +3626,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3960,9 +3960,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4860,14 +4860,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5146,9 +5146,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5262,9 +5262,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5272,16 +5272,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5381,9 +5381,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5497,9 +5497,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5575,9 +5575,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5763,14 +5763,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/chain-interactions/register-foreign-asset/package.json
+++ b/polkadot-docs/chain-interactions/register-foreign-asset/package.json
@@ -12,7 +12,7 @@
     "@polkadot/util-crypto": "^14.0.3"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/register-local-asset/package-lock.json
+++ b/polkadot-docs/chain-interactions/register-local-asset/package-lock.json
@@ -9,25 +9,25 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot/api": "^16.5.6",
-        "@polkadot/keyring": "^14.0.2",
-        "@polkadot/util-crypto": "^14.0.2"
+        "@polkadot/keyring": "^14.0.3",
+        "@polkadot/util-crypto": "^14.0.3"
       },
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.9"
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -36,13 +36,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -70,7 +70,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1961,9 +1961,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -2131,9 +2131,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2509,9 +2509,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3479,9 +3479,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3626,9 +3626,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3960,9 +3960,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4860,14 +4860,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5146,9 +5146,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5262,9 +5262,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5272,16 +5272,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -5381,9 +5381,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5497,9 +5497,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5575,9 +5575,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -5763,14 +5763,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/chain-interactions/register-local-asset/package.json
+++ b/polkadot-docs/chain-interactions/register-local-asset/package.json
@@ -8,11 +8,11 @@
   },
   "dependencies": {
     "@polkadot/api": "^16.5.6",
-    "@polkadot/keyring": "^14.0.2",
-    "@polkadot/util-crypto": "^14.0.2"
+    "@polkadot/keyring": "^14.0.3",
+    "@polkadot/util-crypto": "^14.0.3"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.9"

--- a/polkadot-docs/chain-interactions/runtime-api-calls/package-lock.json
+++ b/polkadot-docs/chain-interactions/runtime-api-calls/package-lock.json
@@ -12,7 +12,7 @@
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@polkadot/api": "^16.5.6",
         "dedot": "^1.0.4",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -34,12 +34,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -48,21 +48,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dedot/api": {
@@ -329,37 +329,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -386,23 +386,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -411,14 +411,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -440,27 +440,27 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -471,21 +471,21 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -502,24 +502,24 @@
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -530,9 +530,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -543,13 +543,13 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -566,24 +566,24 @@
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -594,9 +594,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -617,9 +617,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -638,13 +638,13 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -661,24 +661,24 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -689,9 +689,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -709,13 +709,13 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
@@ -731,24 +731,24 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -759,9 +759,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -784,15 +784,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -809,24 +809,24 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -837,9 +837,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -867,16 +867,16 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -893,14 +893,14 @@
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -911,23 +911,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -944,24 +944,24 @@
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -972,18 +972,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1006,47 +1006,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1087,15 +1077,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -1127,14 +1117,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1145,9 +1135,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1695,9 +1685,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1708,9 +1698,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1721,9 +1711,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1734,9 +1724,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1747,9 +1737,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1760,9 +1750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1773,9 +1763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1786,9 +1776,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1799,9 +1789,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1812,9 +1802,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1815,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -1838,9 +1828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1851,9 +1841,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -1864,9 +1854,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1877,9 +1867,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1890,9 +1880,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1903,9 +1893,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1916,9 +1906,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1929,9 +1919,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1942,9 +1932,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +1945,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1968,9 +1958,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1981,9 +1971,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1994,9 +1984,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +1997,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2158,9 +2148,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2513,12 +2503,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2646,9 +2636,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -2659,32 +2649,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -2892,9 +2882,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -3047,9 +3037,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3236,9 +3226,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -3247,7 +3237,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -3393,28 +3383,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -3445,23 +3435,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -3470,14 +3460,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -3499,9 +3489,9 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3641,12 +3631,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3656,31 +3646,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -3719,9 +3709,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3861,9 +3851,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3990,9 +3980,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/polkadot-docs/chain-interactions/runtime-api-calls/package.json
+++ b/polkadot-docs/chain-interactions/runtime-api-calls/package.json
@@ -11,7 +11,7 @@
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@polkadot/api": "^16.5.6",
     "dedot": "^1.0.4",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/runtime-api-calls/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/runtime-api-calls/tests/docs.test.ts
@@ -4,7 +4,7 @@ import { DedotClient, WsProvider as DedotWsProvider } from "dedot";
 import { execSync } from "child_process";
 import { join } from "path";
 
-const WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network";
+const WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 
 // ---------------------------------------------------------------------------

--- a/polkadot-docs/chain-interactions/runtime-api-calls/tests/runtime_apis.py
+++ b/polkadot-docs/chain-interactions/runtime-api-calls/tests/runtime_apis.py
@@ -1,6 +1,6 @@
 from substrateinterface import SubstrateInterface
 
-POLKADOT_TESTNET_RPC = "wss://asset-hub-paseo.dotters.network"
+POLKADOT_TESTNET_RPC = "wss://api2.zondax.ch/pas/assethub/node/rpc"
 ACCOUNT_ADDRESS = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg"
 
 

--- a/polkadot-docs/chain-interactions/runtime-api-calls/tests/subxt-runtime-api-calls/src/bin/runtime_apis.rs
+++ b/polkadot-docs/chain-interactions/runtime-api-calls/tests/subxt-runtime-api-calls/src/bin/runtime_apis.rs
@@ -6,7 +6,7 @@ use subxt::{OnlineClient, PolkadotConfig};
 #[subxt::subxt(runtime_metadata_path = "polkadot_testnet_metadata.scale")]
 pub mod polkadot_testnet {}
 
-const POLKADOT_TESTNET_RPC: &str = "wss://asset-hub-paseo.dotters.network";
+const POLKADOT_TESTNET_RPC: &str = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 const ACCOUNT_ADDRESS: &str = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 
 #[tokio::main(flavor = "current_thread")]

--- a/polkadot-docs/chain-interactions/send-transactions/README.md
+++ b/polkadot-docs/chain-interactions/send-transactions/README.md
@@ -31,14 +31,14 @@ Connection tests run unconditionally. Send tests require the `SENDER_MNEMONIC` e
 npm ci
 
 # Generate PAPI descriptors
-npx papi add polkadotTestNet -w wss://asset-hub-paseo.dotters.network
+npx papi add polkadotTestNet -w wss://api2.zondax.ch/pas/assethub/node/rpc
 
 # Install Python dependency
 pip install substrate-interface
 
 # Download Subxt metadata and build
 cd tests/subxt-send-transactions
-subxt metadata --url wss://asset-hub-paseo.dotters.network -o asset_hub_metadata.scale
+subxt metadata --url wss://api2.zondax.ch/pas/assethub/node/rpc -o asset_hub_metadata.scale
 cargo build
 cd ../..
 

--- a/polkadot-docs/chain-interactions/send-transactions/package-lock.json
+++ b/polkadot-docs/chain-interactions/send-transactions/package-lock.json
@@ -14,7 +14,7 @@
         "@polkadot/keyring": "^14.0.3",
         "@polkadot/util-crypto": "^14.0.3",
         "dedot": "^1.0.4",
-        "polkadot-api": "^2.0.1"
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -36,12 +36,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -50,21 +50,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@dedot/api": {
@@ -331,37 +331,37 @@
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.2.tgz",
-      "integrity": "sha512-9facPhxg/2fefsN0RiX6PCuJbI3sL2VvRJZmNLqTzenwyk1nSSYFHsJCKwj3HmtD45dC5yBwu5Cl29vxozQIRw==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -388,23 +388,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -413,14 +413,14 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -442,27 +442,27 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/cli/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -473,21 +473,21 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -504,24 +504,24 @@
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/codegen/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -532,9 +532,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -545,13 +545,13 @@
       "link": true
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -568,24 +568,24 @@
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -596,9 +596,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ink-contracts/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -619,9 +619,9 @@
       "optional": true
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.1.tgz",
-      "integrity": "sha512-jAik550rzP3S9Qyhs1zD4+4zaBVF8cYxK037x3Up2N1NJCZTaszuOMQHmIqAQydln+PjJptRW+V4y3IVD93N8g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -640,13 +640,13 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -663,24 +663,24 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -691,9 +691,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/merkleize-metadata/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -711,13 +711,13 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@noble/hashes": {
@@ -733,24 +733,24 @@
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -761,9 +761,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/metadata-compatibility/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -786,15 +786,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -811,24 +811,24 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -839,9 +839,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/pjs-signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -869,16 +869,16 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -895,14 +895,14 @@
       }
     },
     "node_modules/@polkadot-api/signer/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -913,23 +913,23 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signer/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -946,24 +946,24 @@
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -974,18 +974,18 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/signers-common/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -1008,47 +1008,37 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
@@ -1089,15 +1079,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.1.tgz",
-      "integrity": "sha512-WcOa/HZzxiRjgS8bcjPZ7srDPRVKSrs5vC/1CGB0VIkWshgUVm2yylY/CAmU5JcaTfFTmEPNfEZS+/H1e/wR4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -1129,14 +1119,14 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -1147,9 +1137,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1697,9 +1687,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -1710,9 +1700,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -1723,9 +1713,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1736,9 +1726,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1749,9 +1739,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1762,9 +1752,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1775,9 +1765,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1788,9 +1778,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1801,9 +1791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1814,9 +1804,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1827,9 +1817,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -1840,9 +1830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1853,9 +1843,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -1866,9 +1856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1879,9 +1869,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1892,9 +1882,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1905,9 +1895,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1918,9 +1908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1931,9 +1921,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1944,9 +1934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1957,9 +1947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1970,9 +1960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1983,9 +1973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1996,9 +1986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -2009,9 +1999,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -2160,9 +2150,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2515,12 +2505,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2648,9 +2638,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -2661,32 +2651,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -2894,9 +2884,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -3049,9 +3039,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3238,9 +3228,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -3249,7 +3239,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -3395,28 +3385,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.1.tgz",
-      "integrity": "sha512-vM6LhP6WkBL4Y6NweBQlbIwJJm/Jj5j19xd/wau5i6YqRXVRxuKhfujUnBNbJyPY+fBX08XS63gZVHsVqL+FVg==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.2",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.1",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.1",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -3447,23 +3437,23 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -3472,14 +3462,14 @@
       }
     },
     "node_modules/polkadot-api/node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -3501,9 +3491,9 @@
       "license": "MIT"
     },
     "node_modules/polkadot-api/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3643,12 +3633,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3658,31 +3648,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -3721,9 +3711,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3863,9 +3853,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3992,9 +3982,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"

--- a/polkadot-docs/chain-interactions/send-transactions/package.json
+++ b/polkadot-docs/chain-interactions/send-transactions/package.json
@@ -13,7 +13,7 @@
     "@polkadot/keyring": "^14.0.3",
     "@polkadot/util-crypto": "^14.0.3",
     "dedot": "^1.0.4",
-    "polkadot-api": "^2.0.1"
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/polkadot-docs/chain-interactions/send-transactions/tests/docs.test.ts
+++ b/polkadot-docs/chain-interactions/send-transactions/tests/docs.test.ts
@@ -5,7 +5,7 @@ import { DedotClient, WsProvider as DedotWsProvider } from "dedot";
 import { execSync } from "child_process";
 import { join } from "path";
 
-const WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network";
+const WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 // A well-known Paseo testnet address used as recipient when no env var is set
 const FALLBACK_DEST = "5GgbDVeKZwCmMHzn58iFSgSZDTojRMM52arXnuNXto28R7mg";
 

--- a/polkadot-docs/chain-interactions/send-transactions/tests/send_transfer.py
+++ b/polkadot-docs/chain-interactions/send-transactions/tests/send_transfer.py
@@ -2,7 +2,7 @@ import os
 import sys
 from substrateinterface import SubstrateInterface, Keypair
 
-WS_ENDPOINT = "wss://asset-hub-paseo.dotters.network"
+WS_ENDPOINT = "wss://api2.zondax.ch/pas/assethub/node/rpc"
 
 SENDER_MNEMONIC = os.environ.get("SENDER_MNEMONIC")
 DEST_ADDRESS = os.environ.get(

--- a/polkadot-docs/chain-interactions/send-transactions/tests/subxt-send-transactions/src/bin/send_transfer.rs
+++ b/polkadot-docs/chain-interactions/send-transactions/tests/subxt-send-transactions/src/bin/send_transfer.rs
@@ -8,7 +8,7 @@ use subxt_signer::SecretUri;
 #[subxt::subxt(runtime_metadata_path = "asset_hub_metadata.scale")]
 pub mod asset_hub {}
 
-const ASSET_HUB_RPC: &str = "wss://asset-hub-paseo.dotters.network";
+const ASSET_HUB_RPC: &str = "wss://api2.zondax.ch/pas/assethub/node/rpc";
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/polkadot-docs/chain-interactions/transfer-assets-into-polkadot/package-lock.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-into-polkadot/package-lock.json
@@ -8,7 +8,7 @@
       "name": "transfer-assets-into-polkadot",
       "version": "1.0.0",
       "dependencies": {
-        "@paraspell/sdk-pjs": "13.2.2",
+        "@paraspell/sdk-pjs": "13.4.0",
         "ethers": "^6.16.0"
       },
       "devDependencies": {
@@ -473,62 +473,55 @@
       }
     },
     "node_modules/@paraspell/assets": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.2.2.tgz",
-      "integrity": "sha512-UzuudA5IIbzWTwyCtaVZIP7LbeYppW/F2pmC9yAvWcd+YG6jIvh0dEFPzxfsy2HRtgW0fmywH1SghhJghkhZsA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.4.0.tgz",
+      "integrity": "sha512-b4ty8a93PTkIrgzKEOFlaniSS8b61HERoV4rPjFDVlKzXdtends5VgZwnuIPcD2ODUJvPvWSsvpi+BLOl+sXng==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "13.2.2"
+        "@paraspell/sdk-common": "13.4.0"
       }
     },
     "node_modules/@paraspell/pallets": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.2.2.tgz",
-      "integrity": "sha512-2tJaW8z1K7EtW+5Qo/GryAGlddISFlgPRPdLgmwUwh6y0WOn4an9mTzTLsR08fXnIjCKvAiqWYgr+tn/58DrfA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.4.0.tgz",
+      "integrity": "sha512-tGu4a/MW067TnotQllN0HRj4f2rTlJVjB899qjOgmmwPNJtQbCLS3Kg0uQZbStRSB9VjeQYAOjSUPaUlRq+rDg==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "13.2.2"
+        "@paraspell/sdk-common": "13.4.0"
       }
     },
     "node_modules/@paraspell/sdk-common": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.2.2.tgz",
-      "integrity": "sha512-7t5lnLPxZWO5Ymso1pi3R5cJkerxr5mqHeBPg+eIADHCsVMhfwQQxbZusxurhNAYc5TnOsEsX2w5btzTnmrPsg==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.4.0.tgz",
+      "integrity": "sha512-QSOP4bWOVu/IUvvX9lYxIB6I0kQEdHFs6DIgjBqksLP2uk0li23a0t+JfZVdUc7nIrv2tK+z4+DTr54qjHzBBA==",
       "license": "MIT"
     },
     "node_modules/@paraspell/sdk-core": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.2.2.tgz",
-      "integrity": "sha512-CFg32x0G6Bg3R9XdDZriWATC4tYob2nGLPw4mMaBc+CgtQ5xBxEqPZiNPF7PIwIVN52yUxU3pq8bSdPHWbx2Yg==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.4.0.tgz",
+      "integrity": "sha512-w8raLw5FpDZVo71kf1buzHKRMIaDIw7FGyNka5qjWfkA6AEHHXkqQiIIpkY7f3L0OscUgiPNmP8ng1hevjf/Kg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.0.1",
-        "@paraspell/assets": "13.2.2",
-        "@paraspell/pallets": "13.2.2",
-        "@paraspell/sdk-common": "13.2.2",
+        "@paraspell/assets": "13.4.0",
+        "@paraspell/pallets": "13.4.0",
+        "@paraspell/sdk-common": "13.4.0",
         "@scure/base": "^2.0.0",
         "viem": "^2.47.6"
-      },
-      "peerDependencies": {
-        "@paraspell/swap": "^13.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@paraspell/swap": {
-          "optional": true
-        }
       }
     },
     "node_modules/@paraspell/sdk-pjs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-pjs/-/sdk-pjs-13.2.2.tgz",
-      "integrity": "sha512-8+hNOFD3bXtbUzURT7Kln9G7d68I/4pq7L4fcwZc1nOAZseLyN8p0zRy/bs7FwWs10EYhC0iN7bm5bTmsgvkvA==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-pjs/-/sdk-pjs-13.4.0.tgz",
+      "integrity": "sha512-JlmNQ4kKFalrU04nwXHvkGBXOkf5NK2wX3SytyHVJgfoeehl9Nc9QvqvqDRbaiT31q1KmKhRU5rhaXKwNqOyfQ==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-core": "13.2.2",
-        "@snowbridge/api": "^0.4.4",
-        "@snowbridge/base-types": "^0.4.4",
-        "@snowbridge/contract-types": "^0.4.4",
-        "@snowbridge/registry": "^0.4.4",
+        "@paraspell/sdk-core": "13.4.0",
+        "@snowbridge/api": "^1.0.13",
+        "@snowbridge/base-types": "^1.0.13",
+        "@snowbridge/contract-types": "^1.0.13",
+        "@snowbridge/provider-ethers": "^1.0.13",
+        "@snowbridge/registry": "^1.0.13",
         "ethers": "^6.16.0",
         "viem": "^2.47.6"
       },
@@ -727,7 +720,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/util": "14.0.3",
         "@polkadot/util-crypto": "14.0.3",
@@ -746,7 +738,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.3.tgz",
       "integrity": "sha512-/VqTLUDn+Wm8S2L/yaGFddo3oW4vRYav0Rg4pLg/semMZLaN8PJ6h927ucn9JyWdH82QfZfyiIPORt0ZF3isyw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/util": "14.0.3",
         "@substrate/ss58-registry": "^1.51.0",
@@ -921,7 +912,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.3.tgz",
       "integrity": "sha512-mg1NR7ixHlNiz2zbvdcdy1OXZmca2tVA4DpewGpY/qFkW/gq9HdDrHLu7g0k90QnunDcFW4emb7NB60sGJQ0bw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-bigint": "14.0.3",
         "@polkadot/x-global": "14.0.3",
@@ -940,7 +930,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.3.tgz",
       "integrity": "sha512-V00BI6XnZLCkrAmV8uN0eSB6fy48CkxdDZT29cgSMSwHPtY6oKUNgd1ST07PGCL5x8XflwjoA7CTlhdbp1Y9gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
@@ -966,7 +955,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -979,7 +967,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -1093,7 +1080,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.3.tgz",
       "integrity": "sha512-U0al6BKgldFrEbmSObRAlzv9VDs5SMa/rbvZKvvkVec0sWTzYPWQZU1ZC/biXLYdjdKML89BeuCKmXZtCcGhUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
@@ -1107,7 +1093,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-14.0.3.tgz",
       "integrity": "sha512-695c5aPBPtYcnn2zM+u0mXgyNHINlO0qGlGcJq3/0t5NVRZv5KZhk7NNm6antOay9uUjGG40F/r+LPzDT3QamA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "node-fetch": "^3.3.2",
@@ -1122,7 +1107,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.3.tgz",
       "integrity": "sha512-MzMEynJ7HMTy/plLmdyP8rv14RS/6s29HZodUG9aCOscBnEiEDxVEax/ztRJqxhhQuHeYdx0LYDwVbdQDTkqNw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       },
@@ -1135,7 +1119,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.3.tgz",
       "integrity": "sha512-qTPcrk0nIHL2tIu5e0cLj3puQvjCK7onehnqO2fvlmWeIlvDel66fwWs06Ipsib+CwLJdmE6WgNy+8Jv74r6YA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
@@ -1153,7 +1136,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.3.tgz",
       "integrity": "sha512-4RJYDG00iUzQ7YAuS/yvkWRZlkjYU8PUNdJHRfqtJ+SjrSPB7LYYxFhLgw43TZUtHmIueNTsml2Ukv3xXTr2kA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
@@ -1167,7 +1149,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.3.tgz",
       "integrity": "sha512-9HH6o2L+r99wEfXhPb5g+Xwn7qouqD32PsMux7B0dFGR2KNqP4KwO19Hu+gdij6wsEhy7delhZwzHenrWwDfhQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0"
@@ -1181,7 +1162,6 @@
       "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-14.0.3.tgz",
       "integrity": "sha512-tOPdkMye3iuXnuFtdNg5+iSu7Cz9LRL8z5psMuZpUpThMYChGsS2pDFtNvXOKU8ohhO+frY9VdJ9VBg1WL9Iug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-global": "14.0.3",
         "tslib": "^2.8.0",
@@ -1283,9 +1263,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1300,9 +1277,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,9 +1291,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1334,9 +1305,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1351,9 +1319,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1368,9 +1333,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1385,9 +1347,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,9 +1361,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1419,9 +1375,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1436,9 +1389,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1453,9 +1403,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,9 +1417,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,9 +1431,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1663,7 +1604,6 @@
       "resolved": "https://registry.npmjs.org/@scure/sr25519/-/sr25519-0.2.0.tgz",
       "integrity": "sha512-uUuLP7Z126XdSizKtrCGqYyR3b3hYtJ6Fg/XFUXmc2//k2aXHDLqZwFeXxL97gg4XydPROPVnuaHGF2+xriSKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.9.2",
         "@noble/hashes": "~1.8.0"
@@ -1677,7 +1617,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1686,53 +1625,39 @@
       }
     },
     "node_modules/@snowbridge/api": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@snowbridge/api/-/api-0.4.6.tgz",
-      "integrity": "sha512-irmHONDW04Nzk4o+ysfrilTrBTYBv6vhzkHpkpDXvmYDyyNle1zpslpImLXkyE1mdASVUMYn2dpU+7Mva7H1RA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/api/-/api-1.1.9.tgz",
+      "integrity": "sha512-u4IfyiFY/Hf3U7dPri6BqdIhqn708PucSVAT8XXsvggplNEFceDMpRP710gytKB7Amk9eQXe5CoQcpQIrK28fw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "16.4.8",
-        "@polkadot/keyring": "13.5.6",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/util": "13.5.6",
-        "@polkadot/util-crypto": "13.5.6",
-        "@snowbridge/base-types": "0.4.6",
-        "@snowbridge/contract-types": "0.4.6",
-        "ethers": "6.16.0"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@polkadot/api": "16.5.4",
+        "@polkadot/keyring": "14.0.3",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/util": "14.0.3",
+        "@polkadot/util-crypto": "14.0.3",
+        "@snowbridge/base-types": "1.1.9"
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/api": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.4.8.tgz",
-      "integrity": "sha512-72OMPwd47t/ZJB9zIE7d60FqqgCrRqBZqYNkPRBtPYTQNDUsStg3g6hswSp8cdzPua3oKxeamD2GF+BBr0wB3A==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-16.5.4.tgz",
+      "integrity": "sha512-mX1fwtXCBAHXEyZLSnSrMDGP+jfU2rr7GfDVQBz0cBY1nmY8N34RqPWGrZWj8o4DxVu1DQ91sGncOmlBwEl0Qg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api-augment": "16.4.8",
-        "@polkadot/api-base": "16.4.8",
-        "@polkadot/api-derive": "16.4.8",
-        "@polkadot/keyring": "^13.5.6",
-        "@polkadot/rpc-augment": "16.4.8",
-        "@polkadot/rpc-core": "16.4.8",
-        "@polkadot/rpc-provider": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-augment": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/types-create": "16.4.8",
-        "@polkadot/types-known": "16.4.8",
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/util-crypto": "^13.5.6",
+        "@polkadot/api-augment": "16.5.4",
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/api-derive": "16.5.4",
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/rpc-provider": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/types-known": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
         "eventemitter3": "^5.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
@@ -1742,17 +1667,17 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/api-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.4.8.tgz",
-      "integrity": "sha512-hBjSCkQjKqfUmhD1eNFg01Q1kivD5EGnq7zCaKFof+2Y1pdCs9EI5Qa+7MLJFJA0TvHBY6ILt5mSW6Gp/b0dtw==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-16.5.4.tgz",
+      "integrity": "sha512-9FTohz13ih458V2JBFjRACKHPqfM6j4bmmTbcSaE7hXcIOYzm4ABFo7xq5osLyvItganjsICErL2vRn2zULycw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api-base": "16.4.8",
-        "@polkadot/rpc-augment": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-augment": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1760,14 +1685,14 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/api-base": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.4.8.tgz",
-      "integrity": "sha512-RqLG0DFvS99RAWb60r1u5AAnZu6cS1Cit/ASTnzXYysLKVpVd6RCPSZVl+e8NX42pOgGuwh0e1P6LtoIaK2qYQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-16.5.4.tgz",
+      "integrity": "sha512-V69v3ieg5+91yRUCG1vFRSLr7V7MvHPvo/QrzleIUu8tPXWldJ0kyXbWKHVNZEpVBA9LpjGvII+MHUW7EaKMNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-core": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1776,19 +1701,19 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/api-derive": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.4.8.tgz",
-      "integrity": "sha512-qTCVtTNCi95sORld964juDhh8ydbJkUKJK7/4PiZcB3h5dLscBI/Prg6rFRyp0k8w7n0qCvjjBHJrDqov8LPmg==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-16.5.4.tgz",
+      "integrity": "sha512-0JP2a6CaqTviacHsmnUKF4VLRsKdYOzQCqdL9JpwY/QBz/ZLqIKKPiSRg285EVLf8n/hWdTfxbWqQCsRa5NL+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "16.4.8",
-        "@polkadot/api-augment": "16.4.8",
-        "@polkadot/api-base": "16.4.8",
-        "@polkadot/rpc-core": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/util-crypto": "^13.5.6",
+        "@polkadot/api": "16.5.4",
+        "@polkadot/api-augment": "16.5.4",
+        "@polkadot/api-base": "16.5.4",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1796,92 +1721,16 @@
         "node": ">=18"
       }
     },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/keyring": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.6.tgz",
-      "integrity": "sha512-Ybe6Mflrh96FKR5tfEaf/93RxJD7x9UigseNOJW6Yd8LF+GesdxrqmZD7zh+53Hb7smGQWf/0FCfwhoWZVgPUQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.6",
-        "@polkadot/util-crypto": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.6",
-        "@polkadot/util-crypto": "13.5.6"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/networks": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
-      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.9",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/networks/node_modules/@polkadot/util": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
-      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.9",
-        "@polkadot/x-global": "13.5.9",
-        "@polkadot/x-textdecoder": "13.5.9",
-        "@polkadot/x-textencoder": "13.5.9",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/networks/node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
-      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/networks/node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
-      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@snowbridge/api/node_modules/@polkadot/rpc-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.4.8.tgz",
-      "integrity": "sha512-ri5yjmVa0zw56nVQr2P0ozxxz89+RwBUD01sgusNraRbrYOCpNyJlOUsom/1qTVIylyOknzIxpAgFoMkALuqwg==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-16.5.4.tgz",
+      "integrity": "sha512-j9v3Ttqv/EYGezHtVksGJAFZhE/4F7LUWooOazh/53ATowMby3lZUdwInrK6bpYmG2whmYMw/Fo283fwDroBtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-core": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/rpc-core": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1889,15 +1738,15 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/rpc-core": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.4.8.tgz",
-      "integrity": "sha512-LN5BgUeBjGaxybUyFB8WbBU5clwthcMu4XYT0vN4howx/3BvJgBPMvm+K52eWdzSWlPojGtVkNNCy9QTNFWx0w==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-16.5.4.tgz",
+      "integrity": "sha512-92LOSTWujPjtmKOPvfCPs8rAaPFU+18wTtkIzwPwKxvxkN/SWsYSGIxmsoags9ramyHB6jp7Lr59TEuGMxIZzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/rpc-augment": "16.4.8",
-        "@polkadot/rpc-provider": "16.4.8",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/rpc-augment": "16.5.4",
+        "@polkadot/rpc-provider": "16.5.4",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1906,19 +1755,19 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/rpc-provider": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.4.8.tgz",
-      "integrity": "sha512-FD65zi3tBdBYccAWrTbxLP6ZxdU8rJAawD71dx3+RcHwIc5aLHoeK2ZuuXlaLi2LvnhvFDWCm5qJRMElXVYZbA==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-16.5.4.tgz",
+      "integrity": "sha512-mNAIBRA3jMvpnHsuqAX4InHSIqBdgxFD6ayVUFFAzOX8Fh6Xpd4RdI1dqr6a1pCzjnPSby4nbg+VuadWwauVtg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/keyring": "^13.5.6",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-support": "16.4.8",
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/util-crypto": "^13.5.6",
-        "@polkadot/x-fetch": "^13.5.6",
-        "@polkadot/x-global": "^13.5.6",
-        "@polkadot/x-ws": "^13.5.6",
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-support": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
+        "@polkadot/x-fetch": "^14.0.1",
+        "@polkadot/x-global": "^14.0.1",
+        "@polkadot/x-ws": "^14.0.1",
         "eventemitter3": "^5.0.1",
         "mock-socket": "^9.3.1",
         "nock": "^13.5.5",
@@ -1932,17 +1781,17 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.4.8.tgz",
-      "integrity": "sha512-w593kgSlcREBhV349sAzfZI/RTqjVmruZ8vhwxte+nwJnzAINWwM0epFrVVFSQVE+FYjiZrVlH9LWenm5TDx3g==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-16.5.4.tgz",
+      "integrity": "sha512-8Oo1QWaL0DkIc/n2wKBIozPWug/0b2dPVhL+XrXHxJX7rIqS0x8sXDRbM9r166sI0nTqJiUho7pRIkt2PR/DMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/keyring": "^13.5.6",
-        "@polkadot/types-augment": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/types-create": "16.4.8",
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/util-crypto": "^13.5.6",
+        "@polkadot/keyring": "^14.0.1",
+        "@polkadot/types-augment": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/util-crypto": "^14.0.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.8.1"
       },
@@ -1951,14 +1800,14 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types-augment": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.4.8.tgz",
-      "integrity": "sha512-oAJ2okk+z210yS8D3Bj51Bgg5c3L2bAnL7PLnXpfcavGJh8cnvWoEi438lhqPuLKNrTnMw9qrnxH+YRLqRGhqA==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-16.5.4.tgz",
+      "integrity": "sha512-AGjXR+Q9O9UtVkGw/HuOXlbRqVpvG6H8nr+taXP71wuC6RD9gznFBFBqoNkfWHD2w89esNVQLTvXHVxlLpTXqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1966,13 +1815,13 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types-codec": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.4.8.tgz",
-      "integrity": "sha512-JMaXwnaZUwpgHqdpU7zRh2HtDDzMDwYK0qHK5p1UhDK3eArq3rYLUsCvLatC8tNaZUB4wHHBIbG0qSslWHDf+A==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-16.5.4.tgz",
+      "integrity": "sha512-OQtT1pmJu2F3/+Vh1OiXifKoeRy+CU1+Lu7dgTcdO705dnxU4447Zup5JVCJDnxBmMITts/38vbFN2pD225AnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "^13.5.6",
-        "@polkadot/x-bigint": "^13.5.6",
+        "@polkadot/util": "^14.0.1",
+        "@polkadot/x-bigint": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1980,13 +1829,13 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types-create": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.4.8.tgz",
-      "integrity": "sha512-YpI+yv8tsyV1Psn5KjPbAOmZ+KwrmYRxQD1GIbo72LbsEV0mCfELsKJiJLT16xgIe4JaWDKOu4ofgHV42cBmUg==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-16.5.4.tgz",
+      "integrity": "sha512-URQnvr/sgvgIRSxIW3lmml6HMSTRRj2hTZIm6nhMTlYSVT4rLWx0ZbYUAjoPBbaJ+BmoqZ6Bbs+tA+5cQViv5Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -1994,16 +1843,16 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types-known": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.4.8.tgz",
-      "integrity": "sha512-WoyOe1hhaoIfIwhVpCM4foK/9VS1/hlQ1BDRoPfQCIw4UP9Al9a3yU2oabjlIwGR6ivptxIL7BB9/C6jtBU8pQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-16.5.4.tgz",
+      "integrity": "sha512-Dd59y4e3AFCrH9xiqMU4xlG5+Zy0OTy7GQvqJVYXZFyAH+4HYDlxXjJGcSidGAmJcclSYfS3wyEkfw+j1EOVEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/networks": "^13.5.6",
-        "@polkadot/types": "16.4.8",
-        "@polkadot/types-codec": "16.4.8",
-        "@polkadot/types-create": "16.4.8",
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/networks": "^14.0.1",
+        "@polkadot/types": "16.5.4",
+        "@polkadot/types-codec": "16.5.4",
+        "@polkadot/types-create": "16.5.4",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -2011,294 +1860,57 @@
       }
     },
     "node_modules/@snowbridge/api/node_modules/@polkadot/types-support": {
-      "version": "16.4.8",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.4.8.tgz",
-      "integrity": "sha512-rXv4S4QJK3ge5pkiSo83PWNl/SBxibAhvJrV4Myg5vXE/x6iDtd+gOxdz00C2MATaZaSNCsdI78WlK+00jDtCQ==",
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-16.5.4.tgz",
+      "integrity": "sha512-Ra6keCaO73ibxN6MzA56jFq9EReje7jjE4JQfzV5IpyDZdXcmPyJiEfa2Yps/YSP13Gc2e38t9FFyVau0V+SFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "^13.5.6",
+        "@polkadot/util": "^14.0.1",
         "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.6.tgz",
-      "integrity": "sha512-V+CkW2VdhcMWvl7eXdmlCLGqLxrKvXZtXE76KBbPP5n0Z+8DqQ58IHNOE9xe2LOgqDwIzdLlOUwkyF9Zj19y+Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.6",
-        "@polkadot/x-global": "13.5.6",
-        "@polkadot/x-textdecoder": "13.5.6",
-        "@polkadot/x-textencoder": "13.5.6",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util-crypto": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.6.tgz",
-      "integrity": "sha512-1l+t5lVc9UWxvbJe7/3V+QK8CwrDPuQjDK6FKtDZgZCU0JRrjySOxV0J4PeDIv8TgXZtbIcQFVUhIsJTyKZZJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.5.6",
-        "@polkadot/util": "13.5.6",
-        "@polkadot/wasm-crypto": "^7.5.1",
-        "@polkadot/wasm-util": "^7.5.1",
-        "@polkadot/x-bigint": "13.5.6",
-        "@polkadot/x-randomvalues": "13.5.6",
-        "@scure/base": "^1.1.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.6"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.6.tgz",
-      "integrity": "sha512-9HqUIBOHnz9x/ssPb0aOD/7XcU8vGokEYpLoNgexFNIJzqDgrDHXR197iFpkbMqA/+98zagrvYUyPYj1yYs9Jw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "13.5.6",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.6.tgz",
-      "integrity": "sha512-HpqZJ9ud94iK/+0Ofacw7QdtvzFp6SucBBml4XwWZTWoLaLOGDsO7FoWE7yCuwPbX8nLgIM6YmQBeUoZmBtVqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.6.tgz",
-      "integrity": "sha512-iw97n0Bnl2284WgAK732LYR4DW6w5+COfBfHzkhiHqs5xwPEwWMgWGrf2hM8WAQqNIz6Ni8w/jagucPyQBur3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.6.tgz",
-      "integrity": "sha512-HpqZJ9ud94iK/+0Ofacw7QdtvzFp6SucBBml4XwWZTWoLaLOGDsO7FoWE7yCuwPbX8nLgIM6YmQBeUoZmBtVqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.6.tgz",
-      "integrity": "sha512-iw97n0Bnl2284WgAK732LYR4DW6w5+COfBfHzkhiHqs5xwPEwWMgWGrf2hM8WAQqNIz6Ni8w/jagucPyQBur3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
-      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-fetch": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.5.9.tgz",
-      "integrity": "sha512-urwXQZtT4yYROiRdJS6zHu18J/jCoAGpbgPIAjwdqjT11t9XIq4SjuPMxD19xBRhbYe9ocWV8i1KHuoMbZgKbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "node-fetch": "^3.3.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-global": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
-      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-randomvalues": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.6.tgz",
-      "integrity": "sha512-w1F9G7FxrJ7+hGC8bh9/VpPH4KN8xmyzgiQdR7+rVB2V8KsKQBQidG69pj5Kwsh3oODOz0yQYsTG6Rm6TAJbGA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.6",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.6.tgz",
-      "integrity": "sha512-iw97n0Bnl2284WgAK732LYR4DW6w5+COfBfHzkhiHqs5xwPEwWMgWGrf2hM8WAQqNIz6Ni8w/jagucPyQBur3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.6.tgz",
-      "integrity": "sha512-jTGeYCxFh89KRrP7bNj1CPqKO36Onsi0iA6A+5YtRS5wjdQU+/OFM/EHLTP2nvkvZo/tOkOewMR9sausisUvVQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.6.tgz",
-      "integrity": "sha512-iw97n0Bnl2284WgAK732LYR4DW6w5+COfBfHzkhiHqs5xwPEwWMgWGrf2hM8WAQqNIz6Ni8w/jagucPyQBur3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.6.tgz",
-      "integrity": "sha512-iVwz9+OrYCEF9QbNfr9M206mmWvY/AhDmGPfAIeTR4fRgKGVYqcP8RIF8iu/x0MVQWqiVO3vlhlUk7MfrmAnoQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.6",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.6.tgz",
-      "integrity": "sha512-iw97n0Bnl2284WgAK732LYR4DW6w5+COfBfHzkhiHqs5xwPEwWMgWGrf2hM8WAQqNIz6Ni8w/jagucPyQBur3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@polkadot/x-ws": {
-      "version": "13.5.9",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.5.9.tgz",
-      "integrity": "sha512-NKVgvACTIvKT8CjaQu9d0dERkZsWIZngX/4NVSjc01WHmln4F4y/zyBdYn/Z2V0Zw28cISx+lB4qxRmqTe7gbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.9",
-        "tslib": "^2.8.0",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@snowbridge/api/node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@snowbridge/base-types": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@snowbridge/base-types/-/base-types-0.4.6.tgz",
-      "integrity": "sha512-Eszs4y8hGUFoaA3sfgnCvQHwjchRkTwL5PeB3+gBN2Xvb+59n6KYN0+ukjKl8a3BsL8hDW+R/bSAvZ19ccYlVQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/base-types/-/base-types-1.1.9.tgz",
+      "integrity": "sha512-bk/4Hh1qsTwq3dOGKwCdLmyxpy/8snK0cGpUO8k/mq53A5+cmxSXzzFqed/oEb1OM6xONWjEv4E9sSImV14aSg==",
       "license": "Apache-2.0"
     },
     "node_modules/@snowbridge/contract-types": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@snowbridge/contract-types/-/contract-types-0.4.6.tgz",
-      "integrity": "sha512-zCQsjzTvqsKGcDfVjGwf8dvu+GvyLjnGT5JI45GENg4k3lQxBnN6V5y9OlYQZ5sohvfCCdi/BljlOz++e8WWnQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/contract-types/-/contract-types-1.1.9.tgz",
+      "integrity": "sha512-aEewHnMjDHzgzb+NYb0TILN6yY9UslwTsZA61cFg4qSdlvLmZPn7zoNZNY3PeTyeHkANiWOXENAFtdEnJQDTgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snowbridge/contracts": "0.4.6",
+        "@snowbridge/contracts": "1.1.9",
         "ethers": "6.16.0"
       }
     },
     "node_modules/@snowbridge/contracts": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@snowbridge/contracts/-/contracts-0.4.6.tgz",
-      "integrity": "sha512-1LphMvtcr6EgfuQGM3XLwuifVHoPmjfdw5wFVEa+IKLIw7Oh/sxaqWFQXRS+fZX9MKP/bsEGagoD9nYYcBDz4g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/contracts/-/contracts-1.1.9.tgz",
+      "integrity": "sha512-jyM/x+w8Wk9hWRS5NBw2Sp1LEJuD/g+OIwnmsZLAfdrfP0GhEJRK1lrWlOWgFyewxZ0OP8aETgcziSfzQ+ozFQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@snowbridge/registry": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@snowbridge/registry/-/registry-0.4.6.tgz",
-      "integrity": "sha512-CTwQwWuPMPzafky56pBJavxq9ARToJTxdqlfI5/dVaC6rbxDO5/yjUu/jihuVvSNXO/i3pO2DW9fF5KnEvxxbg==",
+    "node_modules/@snowbridge/provider-ethers": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/provider-ethers/-/provider-ethers-1.1.9.tgz",
+      "integrity": "sha512-OK9cnCNRCHQLVIGMIN/m/ivTa7QoP10t3hAB5tRAxEGhq9CTARJz2blyETgF7viARAQyiymo5uMU3DBzG1HsHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snowbridge/base-types": "0.4.6"
+        "@snowbridge/base-types": "1.1.9",
+        "ethers": "6.16.0"
+      }
+    },
+    "node_modules/@snowbridge/registry": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@snowbridge/registry/-/registry-1.1.9.tgz",
+      "integrity": "sha512-/Cq5S4Qh0+mxJud7Y8otysGDY5jx6VWahMRH2i9cAYZS+tZ8t007XIFHkqXExoZY7ZHrkuixaiV+YzT+tzY9DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@snowbridge/base-types": "1.1.9"
       }
     },
     "node_modules/@substrate/connect": {
@@ -2949,9 +2561,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
-      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -3252,9 +2864,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.48.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.4.tgz",
-      "integrity": "sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
       "funding": [
         {
           "type": "github",
@@ -3269,8 +2881,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.20",
-        "ws": "8.18.3"
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -3306,27 +2918,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite": {
@@ -3505,9 +3096,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/polkadot-docs/chain-interactions/transfer-assets-into-polkadot/package.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-into-polkadot/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@paraspell/sdk-pjs": "13.2.2",
+    "@paraspell/sdk-pjs": "13.4.0",
     "ethers": "^6.16.0"
   },
   "devDependencies": {

--- a/polkadot-docs/chain-interactions/transfer-assets-parachains/package-lock.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-parachains/package-lock.json
@@ -8,10 +8,10 @@
       "name": "transfer-assets-parachains",
       "version": "1.0.0",
       "dependencies": {
-        "@paraspell/sdk": "^13.2.2",
-        "@polkadot-labs/hdkd": "^0.0.27",
-        "@polkadot-labs/hdkd-helpers": "^0.0.28",
-        "polkadot-api": "^2.0.1"
+        "@paraspell/sdk": "^13.4.0",
+        "@polkadot-labs/hdkd": "^0.0.28",
+        "@polkadot-labs/hdkd-helpers": "^0.0.30",
+        "polkadot-api": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.12.0",
@@ -26,12 +26,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -40,463 +40,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@commander-js/extra-typings": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
-      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-15.0.0.tgz",
+      "integrity": "sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==",
       "license": "MIT",
       "peerDependencies": {
-        "commander": "~14.0.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+        "commander": "~15.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -546,99 +104,92 @@
       }
     },
     "node_modules/@paraspell/assets": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.2.2.tgz",
-      "integrity": "sha512-UzuudA5IIbzWTwyCtaVZIP7LbeYppW/F2pmC9yAvWcd+YG6jIvh0dEFPzxfsy2HRtgW0fmywH1SghhJghkhZsA==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/assets/-/assets-13.9.0.tgz",
+      "integrity": "sha512-YP4vVqgKlOGXZBllio1FMNjuxKppUNh1ZEuOMFjjtUIZbPMF/SbuwFJlDyhu87l8sby2kpjvKCVKRJ/R06hhaQ==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "13.2.2"
+        "@paraspell/sdk-common": "13.9.0"
       }
     },
     "node_modules/@paraspell/pallets": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.2.2.tgz",
-      "integrity": "sha512-2tJaW8z1K7EtW+5Qo/GryAGlddISFlgPRPdLgmwUwh6y0WOn4an9mTzTLsR08fXnIjCKvAiqWYgr+tn/58DrfA==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/pallets/-/pallets-13.9.0.tgz",
+      "integrity": "sha512-lPYS1C1pv9VxLBn5IlA4T4L/pH9MwhRPAl9Ml0W4xQ69YYllK/4hR6teiJaS903Owg+pO+FgiZU8IIwJ15Qt0A==",
       "license": "MIT",
       "dependencies": {
-        "@paraspell/sdk-common": "13.2.2"
+        "@paraspell/sdk-common": "13.9.0"
       }
     },
     "node_modules/@paraspell/sdk": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk/-/sdk-13.2.2.tgz",
-      "integrity": "sha512-LqkaFmQXoMCVuVRzrKyQalPO281eiWq3CDwa99FWYjvvtoXz2cnoH6/J9+RwaatJzD1ZTOBaGpHtlFNLY/IiWg==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk/-/sdk-13.9.0.tgz",
+      "integrity": "sha512-p3wrr02B/OR9tnMj4yYDwdmGmf0SH8wnpUbLPo5L54eRsYu4fJ7gMow3qfVJ8+cHliD5TqqzFAEnLzjZBnrw3g==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.0.1",
-        "@paraspell/sdk-core": "13.2.2",
-        "@polkadot-labs/hdkd": "^0.0.27",
-        "@polkadot-labs/hdkd-helpers": "^0.0.28",
-        "viem": "^2.47.6"
+        "@noble/hashes": "^2.2.0",
+        "@paraspell/sdk-core": "13.9.0",
+        "@polkadot-api/substrate-bindings": "^0.20.3",
+        "@polkadot-labs/hdkd": "^0.0.28",
+        "@polkadot-labs/hdkd-helpers": "^0.0.30",
+        "viem": "^2.51.3"
       },
       "peerDependencies": {
         "polkadot-api": ">= 2 < 3"
       }
     },
     "node_modules/@paraspell/sdk-common": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.2.2.tgz",
-      "integrity": "sha512-7t5lnLPxZWO5Ymso1pi3R5cJkerxr5mqHeBPg+eIADHCsVMhfwQQxbZusxurhNAYc5TnOsEsX2w5btzTnmrPsg==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-common/-/sdk-common-13.9.0.tgz",
+      "integrity": "sha512-zsvVPTd+WBgYlIVHnUpjdX4HIsLYxYg6Akb6oRb3lA4XfN4Oh5Gw8N5GYQJLBo0eES89J35f/Yynsu6xp9wX+A==",
       "license": "MIT"
     },
     "node_modules/@paraspell/sdk-core": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.2.2.tgz",
-      "integrity": "sha512-CFg32x0G6Bg3R9XdDZriWATC4tYob2nGLPw4mMaBc+CgtQ5xBxEqPZiNPF7PIwIVN52yUxU3pq8bSdPHWbx2Yg==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@paraspell/sdk-core/-/sdk-core-13.9.0.tgz",
+      "integrity": "sha512-jd6cgVEuFtPOt9AC43ganRzvj+rYDvqKHEuQwv8UexfNWYfcZVW9hXkuuLWQD8yAjKev6lOc5yxJQ40i/ZHq7w==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^2.0.1",
-        "@paraspell/assets": "13.2.2",
-        "@paraspell/pallets": "13.2.2",
-        "@paraspell/sdk-common": "13.2.2",
-        "@scure/base": "^2.0.0",
-        "viem": "^2.47.6"
-      },
-      "peerDependencies": {
-        "@paraspell/swap": "^13.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@paraspell/swap": {
-          "optional": true
-        }
+        "@noble/hashes": "^2.2.0",
+        "@paraspell/assets": "13.9.0",
+        "@paraspell/pallets": "13.9.0",
+        "@paraspell/sdk-common": "13.9.0",
+        "@scure/base": "^2.2.0",
+        "viem": "^2.51.3"
       }
     },
     "node_modules/@polkadot-api/cli": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.20.3.tgz",
-      "integrity": "sha512-aEvUuw9Fd+syt430hJjO8q04QNWmuqlOMbD9WZwLdeMAiGR0+F5h/CUF4tSybiNcbL5jDWLTzrraL5qdSfjm3w==",
+      "version": "0.21.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/cli/-/cli-0.21.6.tgz",
+      "integrity": "sha512-1OQ2LvRSHkUcT4WRvLQFJ5PhLLN1Z1o6X1c7dguWW3eZ0bv7I9PWrbE5AyyXcy/jkceKCQ6HyISsfbBv8tIQmw==",
       "license": "MIT",
       "dependencies": {
-        "@commander-js/extra-typings": "^14.0.0",
-        "@polkadot-api/codegen": "0.22.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@commander-js/extra-typings": "^15.0.0",
+        "@polkadot-api/codegen": "0.22.5",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.2",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/known-chains": "0.11.6",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
         "@polkadot-api/wasm-executor": "^0.2.3",
-        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
-        "@types/node": "^25.6.0",
-        "commander": "^14.0.3",
+        "@types/node": "^25.9.4",
+        "commander": "^15.0.0",
         "execa": "^9.6.1",
         "fs.promises.exists": "^1.1.4",
-        "ora": "^9.3.0",
+        "ora": "^9.4.1",
         "read-pkg": "^10.1.0",
-        "rollup": "^4.60.1",
+        "rollup": "^4.62.2",
         "rollup-plugin-esbuild": "^6.2.1",
         "rxjs": "^7.8.2",
         "tsc-prog": "^2.3.0",
-        "typescript": "^6.0.2",
+        "typescript": "^6.0.3",
         "write-package": "^7.2.0"
       },
       "bin": {
@@ -647,18 +198,18 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -669,32 +220,32 @@
       }
     },
     "node_modules/@polkadot-api/cli/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/codegen": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.3.tgz",
-      "integrity": "sha512-TaJpxUOuXFIgrkjhPw/H0fwyKz74R/NL4W3Z0YPkxa89fvMmUqlvnam4e7GzcuR7glcXVTELYY6miCEsg4f+Eg==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/codegen/-/codegen-0.22.5.tgz",
+      "integrity": "sha512-zwZJAlviI211zhj5i6oXkrr0crrbO3GZjBd2vC9AshY1pRmyiNLV9DZsXw4E6l4JQwdAAyNWtPdnvvB9T3TpKg==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/ink-contracts": "0.6.1",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/ink-contracts": "0.6.3",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/ink-contracts": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.1.tgz",
-      "integrity": "sha512-zBuvNSO8V8HLhhWeHvavLJDLrnHNauqfzzvZpqpxVDKEA/dEiyJkZOOtK8OuNdeipCseokwaOyIukTESQGQijg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ink-contracts/-/ink-contracts-0.6.3.tgz",
+      "integrity": "sha512-XqnM1VDzI5L62xgg+f8le2yEoz8QZbUKEfAfPnHMOgBj9tJiyF15FcOJmnLMO/vq3cGixqh18tzJekLG5YTxtA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -711,9 +262,9 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/known-chains": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.2.tgz",
-      "integrity": "sha512-AlOpIbKLcilTf87/unNuZaNQG6IFr9QrP3i7p9SCU1LO8DqVkkWGlQ5CWqnxci1NAXLeRKlSO9M2E/UZVTxdBg==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/known-chains/-/known-chains-0.11.6.tgz",
+      "integrity": "sha512-EEffAbSELaYgUjZN1oiPQuJLshI0kuepr+QcT3Z28CQFRfCfSvhLTI0YE4keJ43b8TnqK5VvE8g4fW/rZqTxoA==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/logs-provider": {
@@ -726,44 +277,44 @@
       }
     },
     "node_modules/@polkadot-api/merkleize-metadata": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.1.tgz",
-      "integrity": "sha512-N6OaCFBQxyCLYobOlbU+ZsyFA7yiTXBWm1yrgjY4UqjpcJPtHgmDQKBnaQwPYSSFRUtNZ36LzMThI+fAnMsRbQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/merkleize-metadata/-/merkleize-metadata-1.2.3.tgz",
+      "integrity": "sha512-WkPbz0p2XQ9c8yXagdnwCHEB70Gnm91okcsd6IXU393//3aPgkxKgb+/Efnz7C5/KQmg02P0zXo7q/n/W/yVCA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-builders": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.1.tgz",
-      "integrity": "sha512-kHgRagFfPnJuuSG2Fm3cHvqPwFkUZ1etkwwGboFCPatOxbovNgf7RGvKcCDwtL1LLeS0sADYw4nUrNyDGiJBCw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.14.3.tgz",
+      "integrity": "sha512-m7CACsiqHzgVEh5WBZGkTV8AQ3CBQKR1YpPQMnlsJfCr/IkgKU0UyWM6WxCmBiReLFVkOfXMtGlpN8+GxpHmww==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/metadata-compatibility": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.1.tgz",
-      "integrity": "sha512-9b5GAukwAkedLh3aw3qWyGAeXKYA493CV0Beqjs1UfjvKSo2BjNXgm3xdMUfi+rgcTE3pkJEu2NMxcmrHmmnIA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-compatibility/-/metadata-compatibility-0.6.3.tgz",
+      "integrity": "sha512-/Y0uF8nDk60ijydp8Bd37YexPFdB8hBXJWwEgOJHsVlhiny8sVKXiMg+UkJ9BiEk2z+yMbZRCKmhNpTpizo7aw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1"
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3"
       }
     },
     "node_modules/@polkadot-api/observable-client": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.4.tgz",
-      "integrity": "sha512-5cp/tzoe3WOwABsIfZNQC2e2vlXMzZ9dSCk6q9lfJj3SN/RRcu4Wpk5G8PxtQj7bZ4OAHnAMdwR6juCeQdDZMw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.18.7.tgz",
+      "integrity": "sha512-/eQi3D8jbXLg/L1hZX4eX0/+nO3kTxkOfYeWEtFhtOvFdfqiiy2DdXG3Zg5QzgHmfG+11p4vSlLiPCC2UvS5Qw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0"
       },
@@ -772,15 +323,15 @@
       }
     },
     "node_modules/@polkadot-api/pjs-signer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.1.tgz",
-      "integrity": "sha512-RdAMTWlkq5DanXPUPDV9Btqi4h2lWHHokrsQokEIOBJRPYdvvR1s7tff6J48jNQkgQYbaYMXuzs+tEDsSafJVA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/pjs-signer/-/pjs-signer-0.7.3.tgz",
+      "integrity": "sha512-U7BLFZfnpFMxCh/scJoLXT6oSbfZtZgMTkiu+TbuWQljAb/1ttrQOfshub5VihNyD5rHajp/2Fq0ONZoL5N5PA==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
@@ -800,35 +351,35 @@
       }
     },
     "node_modules/@polkadot-api/signer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.1.tgz",
-      "integrity": "sha512-dMQpsTGHwIIIrIWh6GPjCztxfGvHF1mgj8P/mgHuhJRy53BzuHVcFqu1f/386Ia0uBidWbBe7U5UKvZ0c+N0xA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signer/-/signer-0.3.3.tgz",
+      "integrity": "sha512-bmEV65TwgwbMfiecl7ZQ3k5lfkCOx9FPwPYkVvALcPiqb/d3zYwT9LL/E00hj+EB6IKMlMelEQVuchcW5i/92w==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
-        "@polkadot-api/merkleize-metadata": "1.2.1",
+        "@polkadot-api/merkleize-metadata": "1.2.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signers-common": "0.2.1",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signers-common": "0.2.3",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/signers-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.1.tgz",
-      "integrity": "sha512-zKTFYv7WFmskM1N1+odpF4flM6tJ7k2EE7PHvm7/LN5N+0Pw0KH1IWjOD2CQcI86k0O6Pau6VrFdKnGKxWKScQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/signers-common/-/signers-common-0.2.3.tgz",
+      "integrity": "sha512-SzGLJMxug31Y1P8+0I809ICpDrayztUXFFh2TV02GuwjEnY6mDGnmX56wowZF5yCn+WteeRdcTJTK7Whk3AGYQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/metadata-builders": "0.14.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       }
     },
     "node_modules/@polkadot-api/sm-provider": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.0.tgz",
-      "integrity": "sha512-Aa7hulTfUfDBavOvweN1ldouqnPJPDpxDI7oTLt23MxoKavHYTansL9aXC+jMoWGx39ycMIsbY0Em04gxFEhDA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/sm-provider/-/sm-provider-0.3.6.tgz",
+      "integrity": "sha512-jRGWSdCWN0SXfYlfyLBvVJ6Nw+C98NVO8yjXzrcvtnahHr9kycFvPyPoE6lETlZejqvr7mMAe1tNSCPAbRFlXA==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
@@ -839,49 +390,39 @@
       }
     },
     "node_modules/@polkadot-api/smoldot": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.0.tgz",
-      "integrity": "sha512-bwXxwAh/QTkBBuovfRk5MIAnuqbN4DmnkdTLoeo8TEsHR5I4J/01rXgPAZ/OHpR5KY+hcjhsdn5Ch1RrWsW71g==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot/-/smoldot-0.4.5.tgz",
+      "integrity": "sha512-CLQ4336BwFKCf0CbHmDldgmfMvLWV2SYBRQA98Wwu9pCNBujZo17c7doqnMeyVLi0b8ijexHD8czUaHfc9CiqQ==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/smoldot-patch": "102.0.0",
-        "@types/node": "^25.5.0",
-        "smoldot": "2.0.40"
-      }
-    },
-    "node_modules/@polkadot-api/smoldot-patch": {
-      "version": "102.0.0",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/smoldot-patch/-/smoldot-patch-102.0.0.tgz",
-      "integrity": "sha512-qOI1B3gOdTNYPb3FNH6jxkVSOOyuFazwMtAZqyi8QZi0VcBnSmKIJ9uzgDRemhIMNHV4vou+zDq1dR4bxDIk0w==",
-      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
-      "dependencies": {
-        "ws": "^8.8.1"
+        "@types/node": "^25.9.1",
+        "smoldot": "~3.2.0"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@polkadot-api/smoldot/node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@polkadot-api/substrate-bindings": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.1.tgz",
-      "integrity": "sha512-AU7uUqSFt6nH8wrD7DJZkmrFs1QjLeA/Z4Qmf03ExUqsKDQ893pPjbQU2qAaPvWzDmaJotT8B8DENRqEUt8ruw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.20.3.tgz",
+      "integrity": "sha512-9iqC71fx1ee9ld1NZV8PFime5vryi0kt1bKCSlvNgO6dqMc06sMZuZ8WPjOzWLCHiKHLuphdMs3rVBBaeCP3yg==",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
         "@polkadot-api/utils": "0.4.0",
-        "@scure/base": "^2.0.0",
+        "@scure/base": "^2.2.0",
         "scale-ts": "^1.6.1"
       }
     },
@@ -909,15 +450,15 @@
       "license": "MIT"
     },
     "node_modules/@polkadot-api/ws-middleware": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.2.tgz",
-      "integrity": "sha512-x3WuA59NrcIbhfFw+LRnlDNRdMRdg9Wz8OCK6HUjjwFfL/O+yNtf/pTGuINuOigZzmBj7hHixPaVw9VJogCN6Q==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@polkadot-api/ws-middleware/-/ws-middleware-0.3.5.tgz",
+      "integrity": "sha512-UuAWlXJTXGELENzXRRyQL0J0lPI6Z0e6NI4ihdspC5q6mlDb79jeERoml6mOmDn+eyIVaWL7z+nNGUree7IT7Q==",
       "license": "MIT",
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.2.0",
         "@polkadot-api/json-rpc-provider-proxy": "0.4.0",
         "@polkadot-api/raw-client": "0.3.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/utils": "0.4.0"
       },
       "peerDependencies": {
@@ -939,31 +480,31 @@
       }
     },
     "node_modules/@polkadot-labs/hdkd": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.27.tgz",
-      "integrity": "sha512-S+cQErugqWhDy9K9uceDmnRiIezVfu/yLLFlBSk6vHQ8/RjtUDS7aTnYWpZlbwR99dNuh077ptd0P8M1tx1DHA==",
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd/-/hdkd-0.0.28.tgz",
+      "integrity": "sha512-LpdqtQRpcgZQ5Mr8J0ddMA5ZufsbI4W3KuJkVdoYMnSmWs4179LigDb1rTYAOtyCg2jWUjf7rWP0mGxQQvNrHw==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-labs/hdkd-helpers": "~0.0.28"
+        "@polkadot-labs/hdkd-helpers": "~0.0.29"
       }
     },
     "node_modules/@polkadot-labs/hdkd-helpers": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.28.tgz",
-      "integrity": "sha512-kENij83Dr76RrcfsJmzcqNhThjWTPtzregb/i6o50kH5n1wkaE58/8PFahMnGVc9Trzk7jxfGSNQphQNwq2emg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@polkadot-labs/hdkd-helpers/-/hdkd-helpers-0.0.30.tgz",
+      "integrity": "sha512-qWmmD6ayj14RenDuDFfjF3sHS7ObqPzwIIMPcSVoDeKFSeQV7RY0HwyhC5CG4i6FoguMzak2dbtjYpNN5XQiwQ==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "^2.0.1",
-        "@noble/hashes": "^2.0.1",
-        "@scure/base": "^2.0.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/base": "^2.2.0",
         "@scure/sr25519": "^1.0.0",
         "scale-ts": "^1.6.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
-      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
       "cpu": [
         "arm"
       ],
@@ -974,9 +515,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
-      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
       "cpu": [
         "arm64"
       ],
@@ -987,9 +528,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
-      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
       "cpu": [
         "arm64"
       ],
@@ -1000,9 +541,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
       "cpu": [
         "x64"
       ],
@@ -1013,9 +554,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
-      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +567,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
-      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
       "cpu": [
         "x64"
       ],
@@ -1039,9 +580,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
-      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
       "cpu": [
         "arm"
       ],
@@ -1052,9 +593,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
-      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
       ],
@@ -1065,9 +606,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
-      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
       "cpu": [
         "arm64"
       ],
@@ -1078,9 +619,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
-      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1091,9 +632,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
-      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
       "cpu": [
         "loong64"
       ],
@@ -1104,9 +645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
-      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
       ],
@@ -1117,9 +658,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
-      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
       "cpu": [
         "ppc64"
       ],
@@ -1130,9 +671,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
-      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
       ],
@@ -1143,9 +684,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
-      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
       "cpu": [
         "riscv64"
       ],
@@ -1156,9 +697,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
-      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1169,9 +710,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
-      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
       "cpu": [
         "s390x"
       ],
@@ -1182,9 +723,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -1195,9 +736,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
-      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
       ],
@@ -1208,9 +749,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
-      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
       "cpu": [
         "x64"
       ],
@@ -1221,9 +762,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
-      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
       "cpu": [
         "arm64"
       ],
@@ -1234,9 +775,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
-      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
       "cpu": [
         "arm64"
       ],
@@ -1247,9 +788,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
-      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
       "cpu": [
         "ia32"
       ],
@@ -1260,9 +801,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
-      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
       "cpu": [
         "x64"
       ],
@@ -1273,9 +814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
-      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
       "cpu": [
         "x64"
       ],
@@ -1295,9 +836,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1449,9 +990,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1717,12 +1258,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1794,9 +1335,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -1807,32 +1348,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/estree-walker": {
@@ -1926,9 +1467,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1966,9 +1507,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -2106,9 +1647,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -2219,9 +1760,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -2230,7 +1771,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -2241,9 +1782,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
-      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -2382,28 +1923,28 @@
       }
     },
     "node_modules/polkadot-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.0.2.tgz",
-      "integrity": "sha512-eYj7VUVuZu4CibGnhJGfixqiGc5IIiJX87fNpW+UVvqht3DxVBWpPpUCDwP6AH4lKY97zgNfp4o18HMgp9aV2Q==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/polkadot-api/-/polkadot-api-2.1.7.tgz",
+      "integrity": "sha512-hSXzpbxtm4DkgBxC1m3ahqCiGTnOI75NmkWOJHlqgR3jmFYzPCMjuURpe8V1gKxzcDWMcffEmgwsM/4nm1Ox5Q==",
       "license": "MIT",
       "dependencies": {
-        "@polkadot-api/cli": "0.20.3",
-        "@polkadot-api/ink-contracts": "0.6.1",
+        "@polkadot-api/cli": "0.21.6",
+        "@polkadot-api/ink-contracts": "0.6.3",
         "@polkadot-api/json-rpc-provider": "0.2.0",
-        "@polkadot-api/known-chains": "0.11.2",
+        "@polkadot-api/known-chains": "0.11.6",
         "@polkadot-api/logs-provider": "0.2.0",
-        "@polkadot-api/metadata-builders": "0.14.1",
-        "@polkadot-api/metadata-compatibility": "0.6.1",
-        "@polkadot-api/observable-client": "0.18.4",
-        "@polkadot-api/pjs-signer": "0.7.1",
+        "@polkadot-api/metadata-builders": "0.14.3",
+        "@polkadot-api/metadata-compatibility": "0.6.3",
+        "@polkadot-api/observable-client": "0.18.7",
+        "@polkadot-api/pjs-signer": "0.7.3",
         "@polkadot-api/polkadot-signer": "0.1.6",
-        "@polkadot-api/signer": "0.3.1",
-        "@polkadot-api/sm-provider": "0.3.0",
-        "@polkadot-api/smoldot": "0.4.0",
-        "@polkadot-api/substrate-bindings": "0.20.1",
+        "@polkadot-api/signer": "0.3.3",
+        "@polkadot-api/sm-provider": "0.3.6",
+        "@polkadot-api/smoldot": "0.4.5",
+        "@polkadot-api/substrate-bindings": "0.20.3",
         "@polkadot-api/substrate-client": "0.7.0",
         "@polkadot-api/utils": "0.4.0",
-        "@polkadot-api/ws-middleware": "0.3.2",
+        "@polkadot-api/ws-middleware": "0.3.5",
         "@polkadot-api/ws-provider": "0.9.0",
         "@rx-state/core": "^0.1.4"
       },
@@ -2516,12 +2057,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
-      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2531,31 +2072,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.1",
-        "@rollup/rollup-android-arm64": "4.60.1",
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-darwin-x64": "4.60.1",
-        "@rollup/rollup-freebsd-arm64": "4.60.1",
-        "@rollup/rollup-freebsd-x64": "4.60.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
-        "@rollup/rollup-linux-arm64-musl": "4.60.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
-        "@rollup/rollup-linux-loong64-musl": "4.60.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1",
-        "@rollup/rollup-linux-x64-musl": "4.60.1",
-        "@rollup/rollup-openbsd-x64": "4.60.1",
-        "@rollup/rollup-openharmony-arm64": "4.60.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
-        "@rollup/rollup-win32-x64-gnu": "4.60.1",
-        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -2594,9 +2135,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2646,9 +2187,9 @@
       }
     },
     "node_modules/smoldot": {
-      "version": "2.0.40",
-      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.40.tgz",
-      "integrity": "sha512-h6XC/kKDLdZBBTI0X8y4ZxmaZ2KYVVB0+5isCQm6j26ljeNjHZUDOV+hf8VyoE23+jg00wrxNJ2IVcIAURxwtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-3.2.0.tgz",
+      "integrity": "sha512-FO332bGlKO1UE0Io0B30omzaHSLjmlN61h6F4MtbwZMdy4XPetphmwVhzv4VUXN7l7prIvRTGrgeqKepL8kNuw==",
       "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
       "dependencies": {
         "ws": "^8.8.1"
@@ -2738,9 +2279,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -2855,9 +2396,9 @@
       "license": "0BSD"
     },
     "node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -2928,9 +2469,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.0.tgz",
-      "integrity": "sha512-0uLzTAUNKPpY9Cf3OBCPdwClXx9CEHAkoVYnxMPdHt7cRI1DobMso+pHZvU7itD+hFwE4htmp9QfP+5lb+kn0g==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
       "funding": [
         {
           "type": "github",
@@ -2945,8 +2486,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.17",
-        "ws": "8.18.3"
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -2985,9 +2526,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3756,9 +3297,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/polkadot-docs/chain-interactions/transfer-assets-parachains/package.json
+++ b/polkadot-docs/chain-interactions/transfer-assets-parachains/package.json
@@ -7,10 +7,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@paraspell/sdk": "^13.2.2",
-    "@polkadot-labs/hdkd": "^0.0.27",
-    "@polkadot-labs/hdkd-helpers": "^0.0.28",
-    "polkadot-api": "^2.0.1"
+    "@paraspell/sdk": "^13.4.0",
+    "@polkadot-labs/hdkd": "^0.0.28",
+    "@polkadot-labs/hdkd-helpers": "^0.0.30",
+    "polkadot-api": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/polkadot-docs/parachains/interoperability/channels-between-parachains/package-lock.json
+++ b/polkadot-docs/parachains/interoperability/channels-between-parachains/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot/api": "^16.5.6",
-        "@polkadot/keyring": "14.0.2"
+        "@polkadot/keyring": "14.0.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -597,7 +597,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/keyring": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
@@ -613,149 +613,6 @@
       "peerDependencies": {
         "@polkadot/util": "14.0.3",
         "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/keyring": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.2.tgz",
-      "integrity": "sha512-TppXBLnchsBPn5fqqJzLa1jBk2MEjZu9o9lbtQzthjW1K+1wyxqr9gS5ftSfutK69fyDc0dIeUxjgt+DHFfxHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/networks": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.2.tgz",
-      "integrity": "sha512-7pxyCbrS4fLWnFSAc55ycWH1gjQGd0Es3PBHBxl+hwHUEh5/xrBVVcXVorOjpv7T/YRmzwtjxskE3KHa4ZiNDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.2.tgz",
-      "integrity": "sha512-3THV5do8Jj3x5izA4gGi6a/FO1gllf9xSCdTTaK1InGv/Nxcc9f2NA92E9D9vEGiWidkQVQdmUNOJe5kjeIKAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.2",
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-randomvalues": "14.0.2",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.2.tgz",
-      "integrity": "sha512-tyjTbPmZmHbk51hBrI8WpkWLYdER4SBXmC5W44w3nn4+k7r8lV9Hm3UGQ9GmrK6kV2cAstoPIbyzKH2jhRdrTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/networks": {
@@ -829,24 +686,6 @@
       },
       "optionalDependencies": {
         "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/types": {
@@ -939,24 +778,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/util": {

--- a/polkadot-docs/parachains/interoperability/channels-between-parachains/package.json
+++ b/polkadot-docs/parachains/interoperability/channels-between-parachains/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@polkadot/api": "^16.5.6",
-    "@polkadot/keyring": "14.0.2"
+    "@polkadot/keyring": "14.0.3"
   }
 }

--- a/polkadot-docs/parachains/interoperability/channels-with-system-parachains/package-lock.json
+++ b/polkadot-docs/parachains/interoperability/channels-with-system-parachains/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot/api": "^16.5.6",
-        "@polkadot/keyring": "14.0.2"
+        "@polkadot/keyring": "14.0.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -597,7 +597,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/keyring": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
@@ -613,149 +613,6 @@
       "peerDependencies": {
         "@polkadot/util": "14.0.3",
         "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/keyring": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.2.tgz",
-      "integrity": "sha512-TppXBLnchsBPn5fqqJzLa1jBk2MEjZu9o9lbtQzthjW1K+1wyxqr9gS5ftSfutK69fyDc0dIeUxjgt+DHFfxHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/networks": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.2.tgz",
-      "integrity": "sha512-7pxyCbrS4fLWnFSAc55ycWH1gjQGd0Es3PBHBxl+hwHUEh5/xrBVVcXVorOjpv7T/YRmzwtjxskE3KHa4ZiNDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.2.tgz",
-      "integrity": "sha512-3THV5do8Jj3x5izA4gGi6a/FO1gllf9xSCdTTaK1InGv/Nxcc9f2NA92E9D9vEGiWidkQVQdmUNOJe5kjeIKAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.2",
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-randomvalues": "14.0.2",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.2.tgz",
-      "integrity": "sha512-tyjTbPmZmHbk51hBrI8WpkWLYdER4SBXmC5W44w3nn4+k7r8lV9Hm3UGQ9GmrK6kV2cAstoPIbyzKH2jhRdrTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/networks": {
@@ -829,24 +686,6 @@
       },
       "optionalDependencies": {
         "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/types": {
@@ -939,24 +778,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/util": {

--- a/polkadot-docs/parachains/interoperability/channels-with-system-parachains/package.json
+++ b/polkadot-docs/parachains/interoperability/channels-with-system-parachains/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@polkadot/api": "^16.5.6",
-    "@polkadot/keyring": "14.0.2"
+    "@polkadot/keyring": "14.0.3"
   }
 }

--- a/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/package-lock.json
+++ b/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@polkadot/api": "^16.5.6",
-        "@polkadot/keyring": "14.0.2"
+        "@polkadot/keyring": "14.0.3"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -597,7 +597,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@polkadot/api/node_modules/@polkadot/keyring": {
+    "node_modules/@polkadot/keyring": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
       "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
@@ -613,149 +613,6 @@
       "peerDependencies": {
         "@polkadot/util": "14.0.3",
         "@polkadot/util-crypto": "14.0.3"
-      }
-    },
-    "node_modules/@polkadot/keyring": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.2.tgz",
-      "integrity": "sha512-TppXBLnchsBPn5fqqJzLa1jBk2MEjZu9o9lbtQzthjW1K+1wyxqr9gS5ftSfutK69fyDc0dIeUxjgt+DHFfxHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/util-crypto": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/networks": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-14.0.2.tgz",
-      "integrity": "sha512-7pxyCbrS4fLWnFSAc55ycWH1gjQGd0Es3PBHBxl+hwHUEh5/xrBVVcXVorOjpv7T/YRmzwtjxskE3KHa4ZiNDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.2",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-14.0.2.tgz",
-      "integrity": "sha512-Zst+dO4Q4W5SLh3cbPS75TyNxLwIzlCWUsGxIZVYhrPCF91UVVbo3ztafFqF85Nu/+/gD4rGbR75vm1cgZ5Rwg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-global": "14.0.2",
-        "@polkadot/x-textdecoder": "14.0.2",
-        "@polkadot/x-textencoder": "14.0.2",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-14.0.2.tgz",
-      "integrity": "sha512-3THV5do8Jj3x5izA4gGi6a/FO1gllf9xSCdTTaK1InGv/Nxcc9f2NA92E9D9vEGiWidkQVQdmUNOJe5kjeIKAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "14.0.2",
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-crypto": "^7.5.3",
-        "@polkadot/wasm-util": "^7.5.3",
-        "@polkadot/x-bigint": "14.0.2",
-        "@polkadot/x-randomvalues": "14.0.2",
-        "@scure/base": "^1.1.7",
-        "@scure/sr25519": "^0.2.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-bigint": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-14.0.2.tgz",
-      "integrity": "sha512-2C0cBFOMJWYYxDR5vAdIRwqt34jm2yHum67HmFiStdQjuFGhiwQA3T+MpGpqhkoHa2ohjKvbjl4HLP7J/MsIdA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-global": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-14.0.2.tgz",
-      "integrity": "sha512-q61vXbGQsm562vyyEUjm4T8/lsbtn32L5fttmdpIUfZeTeyhUpCt5LLsqapF3hgx8XSWxrad+ek0V4yIB0CAPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-randomvalues": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-14.0.2.tgz",
-      "integrity": "sha512-tyjTbPmZmHbk51hBrI8WpkWLYdER4SBXmC5W44w3nn4+k7r8lV9Hm3UGQ9GmrK6kV2cAstoPIbyzKH2jhRdrTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.2",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textdecoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-14.0.2.tgz",
-      "integrity": "sha512-gKdzDFOGKqqUD1nsjY+XEiCSsFPC355RAUaCxAfO/GVr+if5Ah97XM1WDv2DGGuxYS7h/4P7QkfjYlMZDQ+o9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/x-textencoder": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-14.0.2.tgz",
-      "integrity": "sha512-s9sk6VnubV1/PnSiSCHJTlRzGwbtkg1kvW155SXSNg7gIgm7BDahCt+PykqBIsm7Ouwt5Ktxl0FdLXn/7EDGpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "14.0.2",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@polkadot/networks": {
@@ -829,24 +686,6 @@
       },
       "optionalDependencies": {
         "@substrate/connect": "0.8.11"
-      }
-    },
-    "node_modules/@polkadot/rpc-provider/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/types": {
@@ -939,24 +778,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/types/node_modules/@polkadot/keyring": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-14.0.3.tgz",
-      "integrity": "sha512-ozp1dQwaHCjgX/fpTTORmHjxdUNQnyiTVJszpzUaUpvtH/IGZhSU/mSHXMqNETS/g57vQa7NatIDcWfyR9abyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "14.0.3",
-        "@polkadot/util-crypto": "14.0.3"
       }
     },
     "node_modules/@polkadot/util": {

--- a/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/package.json
+++ b/polkadot-docs/parachains/runtime-maintenance/runtime-upgrades/package.json
@@ -13,6 +13,6 @@
   },
   "dependencies": {
     "@polkadot/api": "^16.5.6",
-    "@polkadot/keyring": "14.0.2"
+    "@polkadot/keyring": "14.0.3"
   }
 }

--- a/polkadot-docs/parachains/testing/fork-a-parachain/configs/chopsticks.yml
+++ b/polkadot-docs/parachains/testing/fork-a-parachain/configs/chopsticks.yml
@@ -1,6 +1,5 @@
 endpoint:
-  - wss://rpc.ibp.network/polkadot
-  - wss://polkadot-rpc.dwellir.com
-  - wss://polkadot.public.curie.radiumblock.co/ws
+  - wss://rpc.polkadot.io
+  - wss://polkadot.dotters.network
 mock-signature-host: true
 port: 8000

--- a/polkadot-docs/parachains/testing/fork-a-parachain/package-lock.json
+++ b/polkadot-docs/parachains/testing/fork-a-parachain/package-lock.json
@@ -8,21 +8,21 @@
       "name": "fork-a-parachain-test",
       "version": "1.0.0",
       "devDependencies": {
-        "@acala-network/chopsticks": "1.2.8",
+        "@acala-network/chopsticks": "1.3.1",
         "@types/node": "^22.10.5",
         "typescript": "^5.7.2",
         "vitest": "^2.1.9"
       }
     },
     "node_modules/@acala-network/chopsticks": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.2.8.tgz",
-      "integrity": "sha512-9ozTpSz8d747duYMhttYaBL3rUf51yXiTQLmcZ5gMmQYc77KlEgXntiT5r78gn3J6ZsWl++SGcBj+H66kcwtkA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks/-/chopsticks-1.3.1.tgz",
+      "integrity": "sha512-LrMlezDY8CIMofzCVGWTV7kUDm0XDs/72HVNZ3iFK9GrrVSShOzojHmZXqdzXRCqyJIFxv4nEbksIT0BK02Sqw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
-        "@acala-network/chopsticks-db": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
+        "@acala-network/chopsticks-db": "1.3.1",
         "@dmsnell/diff-match-patch": "^1.1.0",
         "@pnpm/npm-conf": "^3.0.0",
         "@polkadot/api": "^16.4.1",
@@ -31,13 +31,13 @@
         "@polkadot/types": "^16.4.1",
         "@polkadot/util": "^14.0.1",
         "@polkadot/util-crypto": "^14.0.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "comlink": "^4.4.2",
         "dotenv": "^16.6.1",
         "global-agent": "^3.0.0",
         "js-yaml": "^4.1.1",
         "jsondiffpatch": "^0.7.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "ws": "^8.18.3",
         "yargs": "^18.0.0",
         "zod": "^3.25.76"
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.2.8.tgz",
-      "integrity": "sha512-45KxX3TKv83/k7ljUUqI+eq5QpdD4EsBMV++bFuePWOjsqNwdnPXnL7MzmxnTOe1wXAypblD9CLDn7AsJNhUOQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-core/-/chopsticks-core-1.3.1.tgz",
+      "integrity": "sha512-gXoCeVsBRhJkVPp48IDvZTDiJ59l6rLFdg3qUd8crUnBwdUpWhRFmplBevqI+hYwgWnwxHof/959SKU/tAGOuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-executor": "1.2.8",
+        "@acala-network/chopsticks-executor": "1.3.1",
         "@polkadot/rpc-provider": "^16.4.1",
         "@polkadot/types": "^16.4.1",
         "@polkadot/types-codec": "^16.4.1",
@@ -65,7 +65,7 @@
         "@polkadot/util-crypto": "^14.0.1",
         "comlink": "^4.4.2",
         "eventemitter3": "^5.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "lru-cache": "^11.1.0",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -151,13 +151,13 @@
       }
     },
     "node_modules/@acala-network/chopsticks-db": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.2.8.tgz",
-      "integrity": "sha512-ighq/Z2jrh0dbLnob3Im4e1DcYEq+UahIfnUk+ZUTH2lh8ega6zHDHCUazPsw11apqghkd5RgbY0oT6QNAphYQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-db/-/chopsticks-db-1.3.1.tgz",
+      "integrity": "sha512-KSh5ulKBg8nGgJe+BwlPPqlfPxq+w9mKAbY88PU3qnWv9l2O5q+Za9MRLxcV0rwsywTqQdjRKbMqMwxKj1+oEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@acala-network/chopsticks-core": "1.2.8",
+        "@acala-network/chopsticks-core": "1.3.1",
         "@polkadot/util": "^14.0.1",
         "idb": "^8.0.3",
         "reflect-metadata": "^0.2.2",
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@acala-network/chopsticks-executor": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.2.8.tgz",
-      "integrity": "sha512-pSmXFm9zz72lR+Tp0f8Pc/qPKKiNMd/0mFF2pZCl3tvWK2wpIMOw0ez3tc2TL0VuHQb5QhTxSR456B8QZHkOyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@acala-network/chopsticks-executor/-/chopsticks-executor-1.3.1.tgz",
+      "integrity": "sha512-zqt41Sp6va7Iv69X++oCPFFGoGPfpBsmfeHpi18E2UaRmZIui3FHsTTCG7EXhrj8krk/sutS+xnVMK8U8d7zjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3170,7 +3170,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "4"
       },
@@ -3231,9 +3230,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3325,15 +3324,16 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3402,9 +3402,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3494,15 +3494,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -3781,9 +3781,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4037,9 +4037,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4172,9 +4172,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
-      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4217,9 +4217,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -4284,17 +4284,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4586,9 +4586,9 @@
       "optional": true
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4635,7 +4635,6 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -4755,9 +4754,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4903,9 +4902,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5240,9 +5239,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5693,11 +5692,14 @@
       "license": "ISC"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -6143,14 +6145,14 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -6429,9 +6431,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6546,9 +6548,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
-      "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
+      "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6556,16 +6558,16 @@
         "ansis": "^4.2.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "dayjs": "^1.11.19",
+        "dayjs": "^1.11.20",
         "debug": "^4.4.3",
-        "dedent": "^1.7.0",
+        "dedent": "^1.7.2",
         "dotenv": "^16.6.1",
         "glob": "^10.5.0",
         "reflect-metadata": "^0.2.2",
         "sha.js": "^2.4.12",
         "sql-highlight": "^6.1.0",
         "tslib": "^2.8.1",
-        "uuid": "^11.1.0",
+        "uuid": "^11.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -6665,9 +6667,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6781,9 +6783,9 @@
       }
     },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6860,9 +6862,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -7049,14 +7051,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",

--- a/polkadot-docs/parachains/testing/fork-a-parachain/package.json
+++ b/polkadot-docs/parachains/testing/fork-a-parachain/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@acala-network/chopsticks": "1.2.8",
+    "@acala-network/chopsticks": "1.3.1",
     "@types/node": "^22.10.5",
     "typescript": "^5.7.2",
     "vitest": "^2.1.9"

--- a/versions.yml
+++ b/versions.yml
@@ -8,7 +8,7 @@
 
 # Root-level defaults — used unless overridden by a specific dependency below
 polkadot_sdk:
-  release_tag: polkadot-stable2512-3
+  release_tag: polkadot-stable2603-1
   repository: https://github.com/paritytech/polkadot-sdk
 
 parachain_template:
@@ -20,7 +20,7 @@ parachain_template:
   crates:
     polkadot_omni_node:
       name: polkadot-omni-node
-      version: "0.14.0"
+      version: "0.15.0"
     chain_spec_builder:
       name: staging-chain-spec-builder
       version: "16.0.0"
@@ -37,10 +37,13 @@ zombienet:
 crates:
   subxt:
     name: subxt
-    version: "0.50.0"
+    version: "0.50.1"
   subxt_cli:
     name: subxt-cli
-    version: "0.50.0"
+    version: "0.50.1"
+  subxt_signer:
+    name: subxt-signer
+    version: "0.50.1"
   tokio:
     name: tokio
     version: "1.44.2"
@@ -49,7 +52,7 @@ crates:
 javascript_packages:
   polkadot_api:
     name: polkadot-api
-    version: "2.0.1"
+    version: "2.1.0"
   polkadot_js_api:
     name: "@polkadot/api"
     version: "16.5.6"
@@ -61,28 +64,31 @@ javascript_packages:
     version: "0.242.0"
   hardhat_polkadot:
     name: "@parity/hardhat-polkadot"
-    version: "0.2.7"
+    version: "0.3.0"
   resolc:
     name: "@parity/resolc"
-    version: "1.0.0"
+    version: "1.2.0"
+  solc:
+    name: solc
+    version: "0.8.35"
   chopsticks:
     name: "@acala-network/chopsticks"
-    version: "1.2.8"
+    version: "1.3.1"
   paraspell_sdk:
     name: "@paraspell/sdk"
-    version: "13.2.2"
+    version: "13.4.0"
   hdkd:
     name: "@polkadot-labs/hdkd"
-    version: "0.0.27"
+    version: "0.0.28"
   hdkd_helpers:
     name: "@polkadot-labs/hdkd-helpers"
-    version: "0.0.28"
+    version: "0.0.30"
   polkadot_keyring:
     name: "@polkadot/keyring"
-    version: "14.0.2"
+    version: "14.0.3"
   polkadot_js_util_crypto:
     name: "@polkadot/util-crypto"
-    version: "14.0.2"
+    version: "14.0.3"
 
 # Python packages
 python_packages:


### PR DESCRIPTION
## Summary

Companion to **polkadot-developers/polkadot-docs#1716**. Syncs `versions.yml` and the per-harness manifests to the post-update docs `variables.yml`, **plus fixes pre-existing CI breakages** surfaced by running the suite.

### Dependency sync (`versions.yml` + per-harness pins)
| Dependency | From → To |
|---|---|
| `polkadot_sdk.release_tag` | `polkadot-stable2512-3` → `polkadot-stable2603-1` |
| `crates.subxt` / `subxt_cli` (+ `subxt_signer`) | `0.50.0` → `0.50.1` |
| `parachain_template.crates.polkadot_omni_node` | `0.14.0` → `0.15.0` |
| `polkadot_api` | `2.0.1` → `2.1.0` |
| `chopsticks` | `1.2.8` → `1.3.1` |
| `resolc` | `1.0.0` → `1.2.0` |
| `hardhat_polkadot` (+ `solc` 0.8.35) | `0.2.7` → `0.3.0` |
| `paraspell_sdk` | `13.2.2` → `13.4.0` |
| `hdkd` / `hdkd_helpers` | `0.0.27`/`0.0.28` → `0.0.28`/`0.0.30` |
| `polkadot_keyring` / `util-crypto` | `14.0.2` → `14.0.3` |

All 18 affected lockfiles regenerated; `check-js-versions` reports no drift.

### CI fixes (pre-existing failures, not caused by the version bumps)
All 7 workflows that were red were already failing on `master` before this PR, from upstream/infra causes:

1. **`core2` yanked from crates.io** broke the `revive-dev-node` build (Contracts Example, Contracts Precompile dep, REVM Uniswap V2 Core/Periphery). Added `--locked` to `setup-revive-dev-node` so the polkadot-sdk lockfile pins it.
2. **Chopsticks RPC endpoints** in the fork configs (ibp.network, dwellir, amforc, radiumblock) reject GitHub Actions runners. Switched to endpoints proven in CI: `rpc.polkadot.io` (Polkadot) and Zondax/`dotters.network` (Paseo). *(Fork a Parachain, XCM Fee Estimation)*
   - The papi/subxt **chain-interaction** harnesses (calculate-transaction-fees, query-accounts, query-sdks, runtime-api-calls, send-transactions) connected directly to `asset-hub-paseo.dotters.network`, whose metadata fetch (`papi add`/`subxt metadata`) hung with no step timeout. Switched them (TS/Python/Rust/workflows) to Zondax `wss://api2.zondax.ch/pas/assethub/node/rpc` — verified locally (papi add ~10s; calculate-transaction-fees 4/4).
3. **Pay Fees**: `metadata/` is gitignored → `subxt metadata -o` ENOENT on fresh checkout (added `mkdir -p metadata`); and its test teardown ran a broad `pkill -f chopsticks` that SIGTERM'd its own ancestor — replaced with PID-scoped process-group kill (mirrors convert-assets).
4. **Contracts Precompile / `setup-zombienet-eth-rpc`**: from stable2603 the Asset Hub runtime requires the collator to supply relay-parent descendants; the default lookahead collator doesn't, so the parachain panicked and stalled at block #0. Added `--authoring slot-based` to the `polkadot-parachain` collator.

### Verification
- Offline-capable harnesses verified locally (resolc/hardhat/solc compile, subxt pay-fees 0.50.1, keyring/util-crypto, full pay-fees suite 3/3).
- The stable2603-1 zombienet Asset Hub block-production fix (#4) was reproduced and validated locally using the `aarch64-apple-darwin` stable2603-1 binaries: default collator → stuck at #0 (runtime trap); `--authoring slot-based` → blocks produced.
- Network-dependent harnesses validated by this repo's CI (the sandbox used to prepare the PR cannot reach Paseo/Asset-Hub testnet RPCs).

### Out of scope (pre-existing drift)
- subxt test crates query-accounts/query-sdks/runtime-api-calls/send-transactions stay at `0.44.2` (0.44→0.50 is a source migration).
- `dot/sdk` scaffolding templates remain on `polkadot-api` 1.23.3 (separate major).