### PR TITLE
chore: handoff housekeeping (quarterly tasks, drop personal owners)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
-# Default owner for everything
-* @brunopgalvao
-
-# Smart contracts
-/polkadot-docs/smart-contracts/ @nhussein11
-/recipes/contracts/ @nhussein11
+# Code owners for automatic review requests.
+#
+# Cleared on handoff to Parity. Add the new owner team/handles below, e.g.:
+#   * @paritytech/<team>
+#   /polkadot-docs/smart-contracts/ @paritytech/<team>

--- a/.github/workflows/maintainer-tasks.yml
+++ b/.github/workflows/maintainer-tasks.yml
@@ -1,14 +1,14 @@
-name: Weekly Maintainer Tasks
+name: Maintainer Tasks
 
 on:
   schedule:
-    # Every Monday at 9:00 AM Bangkok Time (02:00 UTC)
-    - cron: '0 2 * * 1'
+    # At 02:00 UTC on the 1st of every 3rd month (Jan, Apr, Jul, Oct)
+    - cron: '0 2 1 */3 *'
 
   workflow_dispatch: # Allow manual trigger
 
 jobs:
-  create-weekly-issue:
+  create-maintainer-issue:
     if: github.repository == 'polkadot-developers/polkadot-cookbook'
     runs-on: ubuntu-latest
     permissions:
@@ -44,25 +44,33 @@ jobs:
           } >> $GITHUB_OUTPUT
 
           # Date for title
-          WEEK_OF=$(date -u +"%b %d, %Y")
-          echo "week_of=$WEEK_OF" >> $GITHUB_OUTPUT
+          PERIOD=$(date -u +"%b %d, %Y")
+          echo "period=$PERIOD" >> $GITHUB_OUTPUT
+
+      - name: Ensure label exists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "maintainer-tasks" \
+            --description "Periodic maintainer task checklist" \
+            --color "0e8a16" 2>/dev/null || true
 
       - name: Check for existing open issue
         id: existing
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          EXISTING=$(gh issue list --state open --label "weekly-tasks" --json number --jq '.[0].number // empty')
+          EXISTING=$(gh issue list --state open --label "maintainer-tasks" --json number --jq '.[0].number // empty')
           echo "issue_number=$EXISTING" >> $GITHUB_OUTPUT
 
-      - name: Create weekly issue
+      - name: Create maintainer issue
         if: steps.existing.outputs.issue_number == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LAST_TAG: ${{ steps.context.outputs.last_tag }}
           COMMIT_COUNT: ${{ steps.context.outputs.commit_count }}
           COMMITS: ${{ steps.context.outputs.commits }}
-          WEEK_OF: ${{ steps.context.outputs.week_of }}
+          PERIOD: ${{ steps.context.outputs.period }}
         run: |
           # Build release task text based on whether there are unreleased commits
           if [ "$COMMIT_COUNT" -gt 0 ]; then
@@ -76,7 +84,7 @@ jobs:
             RELEASE_TASK="- [x] **Cut a release** — no unreleased commits since \`$LAST_TAG\` (nothing to release)"
           fi
 
-          BODY="## Weekly Maintainer Tasks
+          BODY="## Maintainer Tasks
 
             ${RELEASE_TASK}
 
@@ -84,18 +92,18 @@ jobs:
 
             ## Periodic Tasks
 
-            _Not required every week — run these when it's been a while._
+            _Not required every time — run these when it's been a while._
 
             - [ ] **Check internal docs** — run \`/check-internal-docs\` to catch stale references, version mismatches, and broken links
 
             ---
 
-            *Created automatically by the [Weekly Maintainer Tasks](.github/workflows/weekly-maintainer-tasks.yml) workflow.*"
+            *Created automatically every 3 months by the [Maintainer Tasks](.github/workflows/maintainer-tasks.yml) workflow.*"
 
           # Strip leading whitespace (12 spaces of YAML indentation)
           BODY=$(printf '%s' "$BODY" | sed 's/^            //')
 
           gh issue create \
-            --title "Weekly tasks — $WEEK_OF" \
-            --label "weekly-tasks" \
+            --title "Maintainer tasks — $PERIOD" \
+            --label "maintainer-tasks" \
             --body "$BODY"

--- a/.github/workflows/post-cleanup.yml
+++ b/.github/workflows/post-cleanup.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Read maintainers
         id: maintainers
         run: |
-          MAINTAINERS=$(cat polkadot-docs/MAINTAINERS | tr '\n' ' ')
+          # Ignore comment (#) and blank lines so placeholder text isn't @-mentioned
+          MAINTAINERS=$(grep -vE '^[[:space:]]*(#|$)' polkadot-docs/MAINTAINERS | tr '\n' ' ')
           echo "list=$MAINTAINERS" >> $GITHUB_OUTPUT
 
       - name: Derive guide path

--- a/polkadot-docs/MAINTAINERS
+++ b/polkadot-docs/MAINTAINERS
@@ -1,2 +1,4 @@
-@brunopgalvao
-@nhussein11
+# Maintainers @-mentioned on CI-failure issues (one GitHub @handle per line).
+# Comment (#) and blank lines are ignored.
+#
+# Cleared on handoff to Parity. Add the new maintainer @handles below.


### PR DESCRIPTION
Housekeeping ahead of handing the repo to Parity maintainers.

## Changes in this PR
- **Maintainer-tasks cadence: weekly → every 3 months.** `weekly-maintainer-tasks.yml` → `maintainer-tasks.yml`; cron `0 2 * * 1` → `0 2 1 */3 *` (1st of Jan/Apr/Jul/Oct, 02:00 UTC). Retitled "Weekly" → "Maintainer", label `weekly-tasks` → `maintainer-tasks`, plus an idempotent `gh label create … || true` so the renamed label can't break the run. _(Closes the cadence ask in #299.)_
- **CODEOWNERS:** removed `@brunopgalvao` + `@nhussein11`; left a placeholder comment for Parity to add their team. No automatic review-requests until then.
- **`polkadot-docs/MAINTAINERS`:** cleared `@brunopgalvao` + `@nhussein11`. This file is `@`-mentioned by `post-cleanup.yml` on CI failures (a bigger ping source than CODEOWNERS), so it mattered. `post-cleanup.yml` now ignores comment/blank lines so the placeholder isn't mentioned.

## Follow-ups NOT in this PR (need owner/Parity action)
- ⚠️ **Recipes live in personal repos** — the harnesses clone `github.com/brunopgalvao/recipe-*` (contracts, contracts-precompile, xcm, network, paseo-local-network, transaction). These should be **transferred to the org**, or recipe CI breaks if the account/repos go away.
- **Repo admin/ownership transfer** to Parity (GitHub settings).
- **Unwatch the repo** to stop notifications regardless of CODEOWNERS.
- **Close stale issue #299** once this merges (the cadence change supersedes it).
- Other weekly automations (sync-versions, check-js-versions, docs-scheduled, migration, pathway tests) left as-is — they keep the repo healthy and don't ping maintainers.