### PR TITLE
Release v0.18.1

### DIFF
--- a/.github/releases/v0.18.1/RELEASE_NOTES.md
+++ b/.github/releases/v0.18.1/RELEASE_NOTES.md
@@ -1,0 +1,60 @@
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.18.1/.github/releases/v0.18.1/cover.svg" alt="Release v0.18.1" width="100%" />
+</div>
+
+# Release v0.18.1
+
+Released: 2026-06-29
+
+## Summary
+
+Syncs the cookbook's tracked dependency versions with polkadot-docs — `polkadot-stable2603-1` plus the latest JS/Rust package set — and repairs the pre-existing CI failures that sync surfaced, so the full test-harness suite is green again. Also prepares the repository for handoff to Parity maintainers.
+
+## What's New
+
+### Infrastructure
+
+- **Synced all tracked dependencies to polkadot-docs** — `polkadot-sdk` to `polkadot-stable2603-1`, plus subxt/subxt-cli `0.50.1`, polkadot-omni-node `0.15.0`, polkadot-api `2.1.0`, chopsticks `1.3.1`, resolc `1.2.0`, hardhat-polkadot `0.3.0`, paraspell `13.4.0`, hdkd-helpers `0.0.30`, keyring/util-crypto `14.0.3`, and solc `0.8.35` across `versions.yml` and the per-harness manifests, keeping the test harnesses aligned with the published tutorials (#298).
+- **Repaired the CI suite** that the bump surfaced — `cargo install --locked` for `revive-dev-node` (the transitive `core2` crate was yanked from crates.io), `--authoring slot-based` for the Asset Hub zombienet collator (stable2603 requires relay-parent descendants or the parachain stalls at block #0), a `mkdir -p metadata` fix plus a PID-scoped chopsticks teardown for the Pay Fees harness, and moved flaky Paseo RPC endpoints to reliable providers (`rpc.polkadot.io` / Zondax) so the chain-interaction harnesses stop hanging on `papi add` (#298).
+
+### Tooling
+
+- **Maintainer tasks now run quarterly** instead of weekly — the auto-created checklist issue opens every 3 months, matching a lighter-touch maintenance cadence (#300).
+- **Handoff preparation** — removed personal code owners and maintainers, leaving placeholders for the incoming Parity team so no stale `@`-mentions fire (#300).
+- **Naming convention** — renamed the Uniswap V2 Core harness test to the `docs.test.ts` convention used across the docs pathway (#296).
+
+## Commits
+
+- chore: sync dependency versions from polkadot-docs (stable2603-1) + CI fixes (#298)
+- chore: handoff housekeeping — quarterly maintainer tasks, drop personal owners (#300)
+- chore: update name to match convention (#296)
+
+## Stats
+
+**3 commits, +4,247 / -6,851 lines**
+
+**Full Changelog:** https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.18.0...v0.18.1
+
+## Compatibility
+
+Tested with:
+- Rust: 1.91.1
+- Node.js: v24.7.0
+
+## Next Steps
+
+Merging the release PR triggers [`publish-release.yml`](../../../.github/workflows/publish-release.yml), which:
+1. Creates the `v0.18.1` git tag
+2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
+3. Publishes the GitHub Release with cover art, manifest, and binaries attached
+
+---
+
+**Status:** Alpha (v0.x.x)
+
+---
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/v0.18.1/.github/releases/v0.18.1/cover-chain.svg" alt="Polkadot network state at v0.18.1 release" width="100%" />
+</div>

--- a/.github/releases/v0.18.1/cover-chain.svg
+++ b/.github/releases/v0.18.1/cover-chain.svg
@@ -1,0 +1,247 @@
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  <rect width="1200" height="630" fill="#0A0A0B"/>
+
+  <!-- ========== MONDRIAN GRID + BLOCKS (same geometry as top cover) ========== -->
+
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 RUNTIME TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#0A0A0B"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#F6F5F2" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ polkadot runtime @ block 31,889,557 ├────────┐
+    </text>
+
+    <text x="774" y="46" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.7s" fill="freeze"/>
+      │ spec_name         polkadot
+    </text>
+    <text x="774" y="60" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.9s" fill="freeze"/>
+      │ spec_version      2,003,000
+    </text>
+    <text x="774" y="74" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.1s" fill="freeze"/>
+      │ impl_name         parity-polkadot
+    </text>
+    <text x="774" y="88" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.3s" fill="freeze"/>
+      │ node              1.24.0-c6fc157a558
+    </text>
+    <text x="774" y="102" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.5s" fill="freeze"/>
+      │ authoring_version 0
+    </text>
+    <text x="774" y="116" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.7s" fill="freeze"/>
+      │ transaction_ver   26
+    </text>
+    <text x="774" y="130" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="2.9s" fill="freeze"/>
+      │ state_version     1
+    </text>
+    <text x="774" y="144" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.75" dur="0.12s" begin="3.1s" fill="freeze"/>
+      │ system_version    1
+    </text>
+    <text x="774" y="158" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0">
+      <animate attributeName="opacity" values="0;0.95" dur="0.15s" begin="3.4s" fill="freeze"/>
+      │ runtime_apis      24 exposed
+    </text>
+
+    <text x="774" y="196" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ state_root  0x6a1d0278..  genesis  0x91b171bb..
+    </text>
+    <text x="774" y="210" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ ss58 0 · DOT · 10 decimals · 6s block target
+    </text>
+    <text x="774" y="224" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.55" letter-spacing="0.4">
+      └─ rpc.polkadot.io · peers 81 · synced ✓ ─────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <!-- No tip-pulse animation: this is a point-in-time reading, not a live chain tip -->
+
+  <!-- ========== FACTUAL OVERLAYS ========== -->
+
+  <!-- B1 PINK: headline + release-time disclaimer badge -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <!-- Disclaimer (the ONE place point-in-time nature is stated) -->
+    <g>
+      <rect x="410" y="22" width="318" height="114" fill="#0A0A0B" opacity="0.5" stroke="#F6F5F2" stroke-opacity="0.8" stroke-width="1"/>
+      <text x="432" y="52" font-size="11" font-weight="700" letter-spacing="1.8" opacity="0.98">◆ POINT-IN-TIME READING</text>
+      <text x="432" y="82" font-size="13" font-weight="700" opacity="0.95">polkadot-cookbook v0.18.1</text>
+      <text x="432" y="104" font-size="10" opacity="0.75">captured 2026-06-29 12:53 UTC</text>
+      <text x="432" y="122" font-size="10" opacity="0.6">mainnet state at release — not live</text>
+    </g>
+
+    <!-- Corner tag -->
+    <text x="36" y="34" font-size="10" letter-spacing="1.5" opacity="0.85">[0x91b171bb] GENESIS</text>
+
+    <!-- Headline -->
+    <text x="36" y="156" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">POLKADOT</text>
+    <text x="36" y="180" font-size="11" letter-spacing="2.5" opacity="0.75">
+      MAINNET  ·  rpc.polkadot.io
+    </text>
+
+    <rect x="36" y="204" width="670" height="1" fill="#F6F5F2" opacity="0.35"/>
+
+    <text x="36" y="230" font-size="10" letter-spacing="1.5" opacity="0.65">FINALIZED BLOCK</text>
+    <text x="36" y="278" font-size="48" font-weight="700" letter-spacing="-0.5" opacity="0.95">#31,889,557</text>
+    <text x="36" y="300" font-size="11" opacity="0.55">0x8f2ae290..b8bd</text>
+
+    <text x="36" y="340" font-size="10" letter-spacing="1.5" opacity="0.65">NETWORK AGE</text>
+    <text x="36" y="362" font-size="13" opacity="0.9"><tspan fill="#F6F5F2" font-weight="700">~6 years, 1 months</tspan>  <tspan opacity="0.55">since 2020-05-26</tspan></text>
+    <text x="36" y="380" font-size="11" opacity="0.6">block 0 → 31,889,557</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SPEC callout -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">RUNTIME SPEC</text>
+    <text x="772" y="316" font-size="26" font-weight="700" opacity="0.95">2,003,000</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">polkadot runtime</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">tx v26 · state v1</text>
+  </g>
+
+  <!-- Empty cell: ref node health -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">REF NODE HEALTH</text>
+    <text x="946" y="302" font-size="12" opacity="0.85">peers       <tspan fill="#E6007A">████████████</tspan>  82</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">syncing     <tspan fill="#E6007A">✓</tspan>     false</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">authoring   <tspan opacity="0.5">—</tspan>     v0</text>
+    <text x="946" y="368" font-size="10" opacity="0.45">NODE  parity-polkadot 1.24.0-c6fc157a558</text>
+  </g>
+
+  <!-- B3 BIG BLUE: network at a glance -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">NETWORK AT A GLANCE</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">[PARA::0] RELAY</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+    <text x="320" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCKS FINALIZED</text>
+    <text x="320" y="514" font-size="28" font-weight="700" opacity="0.95">31,889,557</text>
+    <text x="320" y="534" font-size="10" opacity="0.5">cumulative since genesis</text>
+
+    <text x="560" y="480" font-size="11" letter-spacing="1" opacity="0.6">RUNTIME APIS</text>
+    <text x="560" y="514" font-size="28" font-weight="700" opacity="0.95">24</text>
+    <text x="560" y="534" font-size="10" opacity="0.5">exposed by runtime</text>
+
+    <text x="760" y="480" font-size="11" letter-spacing="1" opacity="0.6">REF NODE PEERS</text>
+    <text x="760" y="514" font-size="28" font-weight="700" opacity="0.95">81</text>
+    <text x="760" y="534" font-size="10" opacity="0.5">via rpc.polkadot.io</text>
+
+    <text x="920" y="480" font-size="11" letter-spacing="1" opacity="0.6">BLOCK TARGET</text>
+    <text x="920" y="514" font-size="28" font-weight="700" opacity="0.95">6s</text>
+    <text x="920" y="534" font-size="10" opacity="0.5">babe slot · network parameter</text>
+
+    <text x="320" y="580" font-size="10" opacity="0.55">Token DOT · 10 decimals · SS58 format 0 · relay chain · para_id 0</text>
+    <text x="320" y="594" font-size="10" opacity="0.45">State root 0x6a1d0278..643c  ·  Genesis 0x91b171bb..ce90c3</text>
+    <text x="320" y="612" font-size="10" opacity="0.55">queried via JSON-RPC  ·  methods: chain_getFinalizedHead · chain_getHeader · state_getRuntimeVersion · system_*</text>
+  </g>
+
+  <!-- B5: chain identity (was the live chain-tip block; now static) -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">
+      <tspan fill="#E6007A" opacity="0.9">◆</tspan> AT COOKBOOK v0.18.1
+    </text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+    <text x="18" y="466" font-size="13" opacity="0.95">CHAIN      <tspan fill="#E6007A" font-weight="700">Polkadot</tspan></text>
+    <text x="18" y="486" font-size="13" opacity="0.95">TYPE       relay</text>
+    <text x="18" y="506" font-size="13" opacity="0.95">PARA_ID    0</text>
+    <text x="18" y="526" font-size="13" opacity="0.95">TOKEN      <tspan fill="#E6007A" font-weight="700">DOT</tspan>  <tspan opacity="0.6">(10 dec)</tspan></text>
+    <text x="18" y="546" font-size="13" opacity="0.95">SS58       0</text>
+    <text x="18" y="566" font-size="13" opacity="0.95">AUTHORING  BABE</text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 0x8f2ae290</text>
+  </g>
+
+  <!-- H2 tickertape — scrolling reference data (ecosystem context, not live feed).
+       Loops slowly so readers can catch all of it; the B1 disclaimer makes the
+       point-in-time nature explicit, so motion here reads as caption, not live data. -->
+  <clipPath id="tick-clip">
+    <rect x="0" y="390" width="1200" height="14"/>
+  </clipPath>
+  <g clip-path="url(#tick-clip)" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="5.3s" fill="freeze"/>
+    <text y="401" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#E6007A" opacity="0.9" letter-spacing="0.8">
+      <animate attributeName="x" from="1200" to="-2800" dur="75s" repeatCount="indefinite" begin="5.3s"/>
+      POLKADOT RELAY  ·  PARA_ID 0  ·  SS58 0  ·  DOT (10 dec)  ·  GENESIS 2020-05-26  ·  BLOCK 0 HASH 0x91b171bb..ce90c3  ·  6s BLOCK TARGET · ≈14,400 blocks/day  ·  BLOCK 31,889,557 · HEAD 0x8f2ae290..b8bd  ·  PARENT 0xf8832d78..759b  ·  STATE ROOT 0x6a1d0278..643c  ·  EXTRINSICS ROOT 0xd2b31539..60aa  ·  RUNTIME SPEC 2,003,000 · 24 APIS · TX_VERSION 26 · STATE_VERSION 1 · SYSTEM_VERSION 1 · AUTHORING_VERSION 0  ·  NODE parity-polkadot 1.24.0-c6fc157a558  ·  QUERIED VIA rpc.polkadot.io  ·  polkadot-cookbook v0.18.1 verified against this runtime
+    </text>
+  </g>
+</svg>

--- a/.github/releases/v0.18.1/cover.svg
+++ b/.github/releases/v0.18.1/cover.svg
@@ -1,0 +1,223 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" shape-rendering="crispEdges">
+  
+  <rect width="1200" height="630" fill="#0A0A0B"/>
+
+  <!-- B1 genesis pink -->
+  <rect x="0" y="0" width="742" height="390" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="0s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="0" width="742" height="390" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="0.6s" begin="0s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="240" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="444" dur="0.5s" begin="0.7s" fill="freeze"/>
+  </rect>
+  <rect x="742" y="0" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="390" dur="0.4s" begin="0.9s" fill="freeze"/>
+  </rect>
+
+  <!-- B2 TERMINAL PANEL -->
+  <g opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="1.3s" fill="freeze"/>
+    <rect x="756" y="0" width="444" height="240" fill="#0A0A0B"/>
+    <rect x="764" y="8" width="428" height="224" fill="none" stroke="#F6F5F2" stroke-opacity="0.15" stroke-width="1"/>
+
+    <text x="774" y="26" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.9" letter-spacing="0.4">
+      ┌─┤ v0.18.0..v0.18.1  2026-06-08 → 06-29 ├────────┐
+    </text>
+
+        <text x="774" y="46" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.7s" fill="freeze"/>
+      │ f19584b ± update name to match convention (#296)
+    </text>
+    <text x="774" y="60" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="1.9s" fill="freeze"/>
+      │ 2064b6b ✓ chore: sync dependency versions from polk…
+    </text>
+    <text x="774" y="74" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0">
+      <animate attributeName="opacity" values="0;0.85" dur="0.12s" begin="2.1s" fill="freeze"/>
+      │ 6398cb5 ✓ chore: handoff housekeeping — quarterly m…
+    </text>
+
+    <text x="774" y="196" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.8" dur="0.2s" begin="3.9s" fill="freeze"/>
+      │ 3 commits · 1 contrib · +4,247 / -6,851 · 77 files
+    </text>
+    <text x="774" y="210" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0" letter-spacing="0.3">
+      <animate attributeName="opacity" values="0;0.75" dur="0.2s" begin="4.1s" fill="freeze"/>
+      │ PRs #296 #298 #300
+    </text>
+    <text x="774" y="224" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace"
+          font-size="10" fill="#F6F5F2" opacity="0.55" letter-spacing="0.4">
+      └─ HEAD 6398cb5 · TAG v0.18.1 ─────────────────────┘
+    </text>
+  </g>
+
+  <rect x="0" y="390" width="0" height="14" fill="#0A0A0B">
+    <animate attributeName="width" from="0" to="1200" dur="0.7s" begin="1.9s" fill="freeze"/>
+  </rect>
+
+  <rect x="297" y="404" width="903" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="2.7s" fill="freeze"/>
+  </rect>
+  <rect x="297" y="404" width="903" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="2.7s" fill="freeze"/>
+  </rect>
+
+  <rect x="756" y="254" width="161" height="136" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="3.3s" fill="freeze"/>
+  </rect>
+  <rect x="756" y="254" width="161" height="136" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.6;0" dur="0.6s" begin="3.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="917" y="240" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="164" dur="0.4s" begin="3.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#0A0A0B" opacity="0">
+    <animate attributeName="opacity" values="0;1" dur="0.35s" begin="4.3s" fill="freeze"/>
+  </rect>
+  <rect x="0" y="404" width="283" height="226" fill="#F6F5F2" opacity="0">
+    <animate attributeName="opacity" values="0;0.5;0" dur="0.6s" begin="4.3s" fill="freeze"/>
+  </rect>
+
+  <rect x="283" y="390" width="14" height="0" fill="#0A0A0B">
+    <animate attributeName="height" from="0" to="240" dur="0.4s" begin="4.6s" fill="freeze"/>
+  </rect>
+
+  <rect x="0" y="404" width="283" height="226" fill="#E6007A" opacity="0">
+    <animate attributeName="opacity" values="0;0.2;0;0.2;0" keyTimes="0;0.25;0.5;0.75;1"
+             dur="4s" begin="6.5s" repeatCount="indefinite"/>
+  </rect>
+
+  <!-- B1 PINK overlay: headline + activity + contributors -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="0.6s" fill="freeze"/>
+
+    <text x="36" y="108" font-size="72" font-weight="700" letter-spacing="-1" opacity="0.97">v0.18.1</text>
+    <text x="36" y="134" font-size="11" letter-spacing="2.5" opacity="0.75">
+      PATCH RELEASE  ·  2026-06-08 → 06-29  ·  21 DAYS
+    </text>
+
+    <rect x="36" y="158" width="670" height="1" fill="#F6F5F2" opacity="0.35"/>
+
+    <text x="36" y="182" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT ACTIVITY</text>
+
+        <text x="36" y="208" font-size="12" opacity="0.9">
+      Mon 06-08  ●  <tspan opacity="0.6">1 commits</tspan>
+    </text>
+    <text x="36" y="226" font-size="12" opacity="0.9">
+      Mon 06-29  ●●  <tspan opacity="0.6">2 commits (incl. release)</tspan>
+    </text>
+
+    <text x="36" y="320" font-size="10" letter-spacing="1.5" opacity="0.65">CONTRIBUTORS</text>
+
+        <text x="36" y="342" font-size="12" opacity="0.9">Bruno Galvao      </text>
+    <rect x="180" y="333" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="40" dur="0.6s" begin="1.30s" fill="freeze"/></rect>
+    <text x="225" y="342" font-size="12" opacity="0.95" font-weight="700">2</text>
+    <text x="36" y="360" font-size="12" opacity="0.9">Erin Shaben       </text>
+    <rect x="180" y="351" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="20" dur="0.6s" begin="1.45s" fill="freeze"/></rect>
+    <text x="205" y="360" font-size="12" opacity="0.95" font-weight="700">1</text>
+  </g>
+
+  <!-- B4 PINK ACCENT: SEMVER -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="3.7s" fill="freeze"/>
+    <text x="772" y="278" font-size="10" letter-spacing="1.5" opacity="0.8">SEMVER</text>
+    <text x="772" y="312" font-size="22" font-weight="700" opacity="0.95">PATCH</text>
+    <text x="772" y="340" font-size="11" opacity="0.8">0.18.0 → 0.18.1</text>
+    <text x="772" y="360" font-size="11" opacity="0.65">21 days · +4,247</text>
+  </g>
+
+  <!-- Empty cell: COMMIT TYPES -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.0s" fill="freeze"/>
+    <text x="946" y="278" font-size="10" letter-spacing="1.5" opacity="0.65">COMMIT TYPES</text>
+
+        <text x="946" y="302" font-size="12" opacity="0.85">» feat   </text>
+    <rect x="1026" y="293" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="0" dur="0.5s" begin="4.20s" fill="freeze"/></rect>
+    <text x="1036" y="302" font-size="12" opacity="0.95" font-weight="700">0</text>
+    <text x="946" y="320" font-size="12" opacity="0.85">✓ fix    </text>
+    <rect x="1026" y="311" width="0" height="10" fill="#E6007A" opacity="0.55"><animate attributeName="width" from="0" to="30" dur="0.5s" begin="4.35s" fill="freeze"/></rect>
+    <text x="1066" y="320" font-size="12" opacity="0.95" font-weight="700">2</text>
+    <text x="946" y="338" font-size="12" opacity="0.85">◆ release</text>
+    <rect x="1026" y="329" width="0" height="10" fill="#E6007A" opacity="1.0"><animate attributeName="width" from="0" to="0" dur="0.5s" begin="4.50s" fill="freeze"/></rect>
+    <text x="1036" y="338" font-size="12" opacity="0.95" font-weight="700">0</text>
+
+    <text x="946" y="368" font-size="10" opacity="0.45">SCOPES  </text>
+  </g>
+
+  <!-- B3 BIG BLUE: bar chart -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.5s" begin="3.1s" fill="freeze"/>
+
+    <text x="320" y="432" font-size="10" letter-spacing="1.5" opacity="0.6">FILES CHANGED BY AREA</text>
+    <text x="1124" y="432" font-size="10" letter-spacing="1.5" opacity="0.6" text-anchor="end">77 TOTAL</text>
+
+    <rect x="320" y="442" width="804" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+        <text x="320" y="466" font-size="12" opacity="0.9">polkadot-docs/chain-interactions</text>
+    <rect x="600" y="457" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="500" dur="0.70s" begin="3.30s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="1110" y="466" font-size="12" opacity="0.95" font-weight="700">52</text>
+    <text x="320" y="484" font-size="12" opacity="0.9">.github/workflows</text>
+    <rect x="600" y="475" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="87" dur="0.53s" begin="3.40s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="697" y="484" font-size="12" opacity="0.95" font-weight="700">9</text>
+    <text x="320" y="502" font-size="12" opacity="0.9">polkadot-docs/parachains</text>
+    <rect x="600" y="493" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="87" dur="0.53s" begin="3.50s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="697" y="502" font-size="12" opacity="0.95" font-weight="700">9</text>
+    <text x="320" y="520" font-size="12" opacity="0.9">.github/actions</text>
+    <rect x="600" y="511" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="19" dur="0.51s" begin="3.60s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="629" y="520" font-size="12" opacity="0.95" font-weight="700">2</text>
+    <text x="320" y="538" font-size="12" opacity="0.9">polkadot-docs/smart-contracts</text>
+    <rect x="600" y="529" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="19" dur="0.51s" begin="3.70s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="629" y="538" font-size="12" opacity="0.95" font-weight="700">2</text>
+    <text x="320" y="556" font-size="12" opacity="0.9">.github/CODEOWNERS</text>
+    <rect x="600" y="547" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="10" dur="0.50s" begin="3.80s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="620" y="556" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="320" y="574" font-size="12" opacity="0.9">polkadot-docs/MAINTAINERS</text>
+    <rect x="600" y="565" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="10" dur="0.50s" begin="3.90s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="620" y="574" font-size="12" opacity="0.95" font-weight="700">1</text>
+    <text x="320" y="592" font-size="12" opacity="0.9">versions.yml</text>
+    <rect x="600" y="583" width="0" height="10" fill="#F6F5F2" opacity="0.5"><animate attributeName="width" from="0" to="10" dur="0.50s" begin="4.00s" fill="freeze" calcMode="spline" keySplines="0.2 0.8 0.2 1" keyTimes="0;1"/></rect>
+    <text x="620" y="592" font-size="12" opacity="0.95" font-weight="700">1</text>
+
+    <text x="320" y="612" font-size="10" opacity="0.55">+4,247 insertions · -6,851 deletions · Δ ratio 0:1 (cleanup release)</text>
+  </g>
+
+  <!-- B5 HEAD: repo state -->
+  <g opacity="0" font-family="'JetBrains Mono', ui-monospace, Menlo, Consolas, 'Courier New', monospace" fill="#F6F5F2">
+    <animate attributeName="opacity" values="0;1" dur="0.4s" begin="4.9s" fill="freeze"/>
+    <text x="18" y="432" font-size="10" letter-spacing="1.5" opacity="0.65">REPO @ v0.18.1</text>
+
+    <rect x="18" y="442" width="247" height="1" fill="#F6F5F2" opacity="0.25"/>
+
+        <text x="18" y="466" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700">40</tspan>  docs test harnesses
+    </text>
+    <text x="18" y="486" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 8</tspan>  recipes
+    </text>
+    <text x="18" y="506" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 2</tspan>  migration tests
+    </text>
+    <text x="18" y="526" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700">65</tspan>  CI workflows
+    </text>
+    <text x="18" y="546" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 6</tspan>  Claude skills
+    </text>
+    <text x="18" y="566" font-size="13" opacity="0.95">
+      <tspan fill="#E6007A" font-weight="700"> 2</tspan>  Rust crates
+    </text>
+
+    <text x="18" y="614" font-size="10" opacity="0.55">HEAD 6398cb5</text>
+  </g>
+</svg>

--- a/.github/releases/v0.18.1/manifest.yml
+++ b/.github/releases/v0.18.1/manifest.yml
@@ -1,0 +1,8 @@
+release: v0.18.1
+previous_release: v0.18.0
+release_date: 2026-06-29T00:00:00Z
+status: alpha
+
+tooling:
+  rust: "1.91.1"
+  node: "v24.7.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-06-29
+
+### Changed
+- Synced tracked dependency versions to polkadot-docs: `polkadot-sdk` `polkadot-stable2603-1`, subxt/subxt-cli `0.50.1`, polkadot-omni-node `0.15.0`, polkadot-api `2.1.0`, chopsticks `1.3.1`, resolc `1.2.0`, hardhat-polkadot `0.3.0`, paraspell `13.4.0`, hdkd-helpers `0.0.30`, keyring/util-crypto `14.0.3`, solc `0.8.35` (across `versions.yml` and per-harness manifests)
+- Maintainer-tasks workflow now runs every 3 months instead of weekly (renamed to `maintainer-tasks.yml`)
+- Removed personal code owners and maintainers ahead of the Parity handoff, leaving placeholders for the incoming team
+- Renamed the Uniswap V2 Core harness test to the `docs.test.ts` convention
+
+### Fixed
+- `revive-dev-node` build now uses `cargo install --locked` (the transitive `core2` crate was yanked from crates.io)
+- Asset Hub zombienet collator uses `--authoring slot-based`, required from stable2603 (relay-parent descendants); without it the parachain stalled at block #0
+- Pay Fees harness: create the gitignored `metadata/` dir before `subxt metadata`, and kill only the chopsticks process group on teardown (no broad `pkill`)
+- Chain-interaction and chopsticks harnesses moved off flaky Paseo RPC providers to `rpc.polkadot.io` / Zondax so `papi add` no longer hangs
+
 ## [0.18.0] - 2026-05-21
 
 ### Added
@@ -115,7 +129,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Source URLs after upstream docs restructured periphery page
 - CI cache key to reference `docs.test.ts` after test file rename
 
-[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/polkadot-developers/polkadot-cookbook/compare/v0.15.1...v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cli"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -993,7 +993,7 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdk"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "cliclack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ default-members = ["dot/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 authors = ["Polkadot Cookbook Contributors"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION

<div align="center">
  <img src="https://raw.githubusercontent.com/polkadot-developers/polkadot-cookbook/06bbe50/.github/releases/v0.18.1/cover.svg" alt="Release v0.18.1" width="100%" />
</div>

## Release v0.18.1 · PATCH bump

4 commits · 2 contributors · +4,804 / -6,855 lines · 84 files changed · `v0.18.0` → `v0.18.1`

## Summary

Syncs the cookbook's tracked dependency versions with polkadot-docs — `polkadot-stable2603-1` plus the latest JS/Rust package set — and repairs the pre-existing CI failures that sync surfaced, so the full test-harness suite is green again. Also prepares the repository for handoff to Parity maintainers.

## What's New

### Infrastructure

- **Synced all tracked dependencies to polkadot-docs** — `polkadot-sdk` to `polkadot-stable2603-1`, plus subxt/subxt-cli `0.50.1`, polkadot-omni-node `0.15.0`, polkadot-api `2.1.0`, chopsticks `1.3.1`, resolc `1.2.0`, hardhat-polkadot `0.3.0`, paraspell `13.4.0`, hdkd-helpers `0.0.30`, keyring/util-crypto `14.0.3`, and solc `0.8.35` across `versions.yml` and the per-harness manifests, keeping the test harnesses aligned with the published tutorials (#298).
- **Repaired the CI suite** that the bump surfaced — `cargo install --locked` for `revive-dev-node` (the transitive `core2` crate was yanked from crates.io), `--authoring slot-based` for the Asset Hub zombienet collator (stable2603 requires relay-parent descendants or the parachain stalls at block #0), a `mkdir -p metadata` fix plus a PID-scoped chopsticks teardown for the Pay Fees harness, and moved flaky Paseo RPC endpoints to reliable providers (`rpc.polkadot.io` / Zondax) so the chain-interaction harnesses stop hanging on `papi add` (#298).

### Tooling

- **Maintainer tasks now run quarterly** instead of weekly — the auto-created checklist issue opens every 3 months, matching a lighter-touch maintenance cadence (#300).
- **Handoff preparation** — removed personal code owners and maintainers, leaving placeholders for the incoming Parity team so no stale `@`-mentions fire (#300).
- **Naming convention** — renamed the Uniswap V2 Core harness test to the `docs.test.ts` convention used across the docs pathway (#296).

## Test plan

- [x] `cargo fmt --check --package sdk` passes
- [x] `cargo clippy --package sdk --locked -- -D warnings` passes
- [x] `cargo build --workspace --locked` succeeds
- [x] `cargo test --package sdk --lib --locked -- --test-threads=1` passes
- [x] `CHANGELOG.md` updated with this release's entries
- [x] `Cargo.toml` workspace version bumped to `0.18.1`
- [x] `.github/releases/v0.18.1/RELEASE_NOTES.md` reviewed and looks right
- [x] `.github/releases/v0.18.1/cover.svg` renders correctly (check in browser — xmllint alone doesn't prove it renders)
- [x] `.github/releases/v0.18.1/cover-chain.svg` renders correctly (skip check-off if the chain-RPC was unreachable and the footer cover was omitted)

## Next Steps

Merging this PR triggers [`publish-release.yml`](../blob/master/.github/workflows/publish-release.yml), which:
1. Creates the `v0.18.1` git tag
2. Builds the `dot` CLI binaries for Linux, macOS (Intel + ARM), and Windows
3. Publishes the GitHub Release with cover art, manifest, and binaries attached
